### PR TITLE
:sparkles: CollegeMajor 앤티티 생성 & 조회 기능 추가

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/college/api/CollegeMajorController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/college/api/CollegeMajorController.java
@@ -1,0 +1,31 @@
+package com.sejong.sejongpeer.domain.college.api;
+
+import com.sejong.sejongpeer.domain.college.dto.CollegeMajorResponse;
+import com.sejong.sejongpeer.domain.college.service.CollegeMajorService;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/colleges")
+@RequiredArgsConstructor
+public class CollegeMajorController {
+
+	private final CollegeMajorService collegeMajorService;
+
+	@GetMapping
+	public List<String> getAllDistinctColleges() {
+		return collegeMajorService.getAllColleges();
+	}
+
+	@GetMapping("/majors")
+	public List<CollegeMajorResponse> getMajorsByCollege(@RequestParam(name = "college") String college) {
+		return collegeMajorService.getAllMajorsByCollege(college);
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/college/dto/CollegeMajorResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/college/dto/CollegeMajorResponse.java
@@ -1,0 +1,5 @@
+package com.sejong.sejongpeer.domain.college.dto;
+
+public record CollegeMajorResponse(
+        String college,
+        String major) {}

--- a/src/main/java/com/sejong/sejongpeer/domain/college/entity/CollegeMajor.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/college/entity/CollegeMajor.java
@@ -1,0 +1,38 @@
+package com.sejong.sejongpeer.domain.college.entity;
+
+import org.hibernate.annotations.Comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "college-major-relations")
+public class CollegeMajor {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Comment("단과대 이름")
+	@Column(length = 30, nullable = false)
+	private String college;
+
+	@Comment("학과 이름")
+	@Column(length = 30, nullable = false)
+	private String major;
+
+	@Builder
+	private CollegeMajor(String college, String major) {
+		this.college = college;
+		this.major = major;
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/college/repository/CollegeMajorRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/college/repository/CollegeMajorRepository.java
@@ -1,0 +1,16 @@
+package com.sejong.sejongpeer.domain.college.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.sejong.sejongpeer.domain.college.entity.CollegeMajor;
+
+public interface CollegeMajorRepository extends JpaRepository<CollegeMajor, Long> {
+
+	@Query("SELECT DISTINCT cm.college FROM CollegeMajor cm")
+	List<String> findAllColleges();
+
+	List<CollegeMajor> findAllByCollege(String college);
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/college/service/CollegeMajorService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/college/service/CollegeMajorService.java
@@ -1,0 +1,30 @@
+package com.sejong.sejongpeer.domain.college.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sejong.sejongpeer.domain.college.dto.CollegeMajorResponse;
+import com.sejong.sejongpeer.domain.college.entity.CollegeMajor;
+import com.sejong.sejongpeer.domain.college.repository.CollegeMajorRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CollegeMajorService {
+
+	private final CollegeMajorRepository collegeMajorRepository;
+
+	public List<String> getAllColleges() {
+		return collegeMajorRepository.findAllColleges();
+	}
+
+	public List<CollegeMajorResponse> getAllMajorsByCollege(String college) {
+		return collegeMajorRepository.findAllByCollege(college).stream()
+			.map(cm -> new CollegeMajorResponse(cm.getCollege(), cm.getMajor()))
+			.toList();
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/college/service/CollegeMajorService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/college/service/CollegeMajorService.java
@@ -1,6 +1,7 @@
 package com.sejong.sejongpeer.domain.college.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,18 +14,19 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CollegeMajorService {
 
 	private final CollegeMajorRepository collegeMajorRepository;
 
+	@Transactional(readOnly = true)
 	public List<String> getAllColleges() {
 		return collegeMajorRepository.findAllColleges();
 	}
 
+	@Transactional(readOnly = true)
 	public List<CollegeMajorResponse> getAllMajorsByCollege(String college) {
 		return collegeMajorRepository.findAllByCollege(college).stream()
 			.map(cm -> new CollegeMajorResponse(cm.getCollege(), cm.getMajor()))
-			.toList();
+			.collect(Collectors.toUnmodifiableList());
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/college/service/CollegeMajorService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/college/service/CollegeMajorService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CollegeMajorService {
 
 	private final CollegeMajorRepository collegeMajorRepository;

--- a/src/test/java/com/sejong/sejongpeer/domain/college/repository/CollegeMajorRepositoryTest.java
+++ b/src/test/java/com/sejong/sejongpeer/domain/college/repository/CollegeMajorRepositoryTest.java
@@ -16,7 +16,6 @@ import com.sejong.sejongpeer.domain.college.entity.CollegeMajor;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Transactional
 class CollegeMajorRepositoryTest {
 
 	@Autowired

--- a/src/test/java/com/sejong/sejongpeer/domain/college/repository/CollegeMajorRepositoryTest.java
+++ b/src/test/java/com/sejong/sejongpeer/domain/college/repository/CollegeMajorRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.sejong.sejongpeer.domain.college.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sejong.sejongpeer.domain.college.entity.CollegeMajor;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+class CollegeMajorRepositoryTest {
+
+	@Autowired
+	private CollegeMajorRepository collegeMajorRepository;
+
+	@BeforeEach
+	void setUp() {
+		List<CollegeMajor> collegeMajors = Arrays.asList(
+			CollegeMajor.builder().college("인문과학대학").major("국어국문학과").build(),
+			CollegeMajor.builder().college("인문과학대학").major("국제학부").build(),
+			CollegeMajor.builder().college("인문과학대학").major("국제학부 영어영문학전공").build(),
+			CollegeMajor.builder().college("인문과학대학").major("국제학부 일어일문학전공").build(),
+			CollegeMajor.builder().college("인문과학대학").major("국제학부 중국통상학전공").build(),
+			CollegeMajor.builder().college("인문과학대학").major("역사학과").build(),
+			CollegeMajor.builder().college("인문과학대학").major("교육학과").build(),
+			CollegeMajor.builder().college("사회과학대학").major("행정학과").build(),
+			CollegeMajor.builder().college("사회과학대학").major("미디어커뮤니케이션학과").build(),
+			CollegeMajor.builder().college("경영경제대학").major("경영학부").build()
+		);
+
+		collegeMajorRepository.saveAll(collegeMajors);
+	}
+
+	@Test
+	void findAllColleges() {
+		List<String> colleges = collegeMajorRepository.findAllColleges();
+
+		assertThat(colleges).isNotEmpty();
+	}
+
+	@Test
+	void findAllByCollege() {
+		List<CollegeMajor> majors = collegeMajorRepository.findAllByCollege("인문과학대학");
+
+		assertThat(majors).isNotEmpty();
+	}
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #18 

## 📌 작업 내용 및 특이사항
- 단과대 목록을 가져오는 기능을 구현했습니다.
- 단과대 이름을 파라미터로 소속된 학과과 목록을 가져오는 기능을 구현했습니다.
- 학교 공지사항의 개설 과목 엑셀파일을 참고하여 college-major-relations 테이블에 단과대 - 학과 정보를 넣었습니다.
