### PR TITLE
🐛 짝매칭 성사가 되었을 때 BuddyMatched 엔티티에서 target Buddy만을 받아오는 문제 해결

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
@@ -83,8 +83,12 @@ public class BuddyMatchingService {
 
 	private Buddy findTargetBuddy(Buddy ownerBuddy) {
 		Optional<BuddyMatched> optionalBuddyMatched = buddyMatchedRepository.findLatestByOwnerOrPartner(ownerBuddy);
-
-		return optionalBuddyMatched.map(BuddyMatched::getPartner).orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND));
+		BuddyMatched selectedBuddyMatched = optionalBuddyMatched.orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND));
+		if (selectedBuddyMatched.getOwner() == ownerBuddy) {
+			return selectedBuddyMatched.getPartner();
+		} else {
+			return selectedBuddyMatched.getOwner();
+		}
 	}
 
 	private void sendMatchingMessage(Buddy matchingSuccessBuddy) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #77 

## 📌 작업 내용 및 특이사항
- findTargetBuddy 메소드에서 getPartner를 통해 항상 partner 필드의 buddy를 반환하는 문제에 대한 수정

## 📝 참고사항
- 

## 📚 기타
- 
