### PR TITLE
✨ Buddy, BuddyMatched가 Complete일 때 응답 메소드 구현

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyController.java
@@ -3,7 +3,7 @@ package com.sejong.sejongpeer.domain.buddy.api;
 import com.sejong.sejongpeer.domain.buddy.dto.request.RegisterRequest;
 import com.sejong.sejongpeer.domain.buddy.dto.response.CompletedPartnerInfoResponse;
 import com.sejong.sejongpeer.domain.buddy.dto.response.MatchingStatusResponse;
-import com.sejong.sejongpeer.domain.buddy.dto.response.PartnerInfoResponse;
+import com.sejong.sejongpeer.domain.buddy.dto.response.MatchingPartnerInfoResponse;
 import com.sejong.sejongpeer.domain.buddy.service.BuddyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -47,9 +47,9 @@ public class BuddyController {
 		return buddyService.getMatchingStatus(memberId);
 	}
 
-	@Operation(summary = "버디 매칭 후 상대방 정보요청", description = "매칭 후 상대방의 정보 리턴")
+	@Operation(summary = "버디 수락/거절 창에서의 상대방 정보 요청", description = "매칭 후 상대방의 학과, 학년 정보 리턴")
 	@GetMapping("/partner/details")
-	public PartnerInfoResponse getPartnerDetails() {
+	public MatchingPartnerInfoResponse getPartnerDetails() {
 		String memberId =
 			(String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		return buddyService.getPartnerDetails(memberId);

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyController.java
@@ -2,6 +2,7 @@ package com.sejong.sejongpeer.domain.buddy.api;
 
 import com.sejong.sejongpeer.domain.buddy.dto.request.RegisterRequest;
 import com.sejong.sejongpeer.domain.buddy.dto.response.MatchingStatusResponse;
+import com.sejong.sejongpeer.domain.buddy.dto.response.PartnerInfoResponse;
 import com.sejong.sejongpeer.domain.buddy.service.BuddyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,5 +45,14 @@ public class BuddyController {
 			(String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		return buddyService.getMatchingStatus(memberId);
 	}
+
+	@Operation(summary = "버디 매칭 후 상대방 정보요청", description = "매칭 후 상대방의 정보 리턴")
+	@GetMapping("/partner/details")
+	public PartnerInfoResponse getPartnerDetails() {
+		String memberId =
+			(String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		return buddyService.getPartnerDetails(memberId);
+	}
 }
+
 

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyController.java
@@ -1,6 +1,7 @@
 package com.sejong.sejongpeer.domain.buddy.api;
 
 import com.sejong.sejongpeer.domain.buddy.dto.request.RegisterRequest;
+import com.sejong.sejongpeer.domain.buddy.dto.response.CompletedPartnerInfoResponse;
 import com.sejong.sejongpeer.domain.buddy.dto.response.MatchingStatusResponse;
 import com.sejong.sejongpeer.domain.buddy.dto.response.PartnerInfoResponse;
 import com.sejong.sejongpeer.domain.buddy.service.BuddyService;
@@ -52,6 +53,14 @@ public class BuddyController {
 		String memberId =
 			(String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		return buddyService.getPartnerDetails(memberId);
+	}
+
+	@Operation(summary = "매칭 수락 완료 후 상대방 정보요청", description = "이름, 학년, 학과, 카카오톡 정보 리턴")
+	@GetMapping("/matched/partner/details")
+	public CompletedPartnerInfoResponse getBuddyMatchedPartnerDetails() {
+		String memberId =
+			(String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		return buddyService.getBuddyMatchedPartnerDetails(memberId);
 	}
 }
 

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/CompletedPartnerInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/CompletedPartnerInfoResponse.java
@@ -1,0 +1,9 @@
+package com.sejong.sejongpeer.domain.buddy.dto.response;
+
+public record CompletedPartnerInfoResponse(
+	String collegeMajor,
+	Integer grade,
+	String name,
+	String kakaoAccount
+) {
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/CompletedPartnerInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/CompletedPartnerInfoResponse.java
@@ -8,7 +8,7 @@ public record CompletedPartnerInfoResponse(
 	String name,
 	String kakaoAccount
 ) {
-	public static CompletedPartnerInfoResponse from(Member member) {
+	public static CompletedPartnerInfoResponse memberFrom(Member member) {
 		return new CompletedPartnerInfoResponse(
 			member.getCollegeMajor().getMajor(),
 			member.getGrade(),

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/CompletedPartnerInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/CompletedPartnerInfoResponse.java
@@ -1,9 +1,19 @@
 package com.sejong.sejongpeer.domain.buddy.dto.response;
 
+import com.sejong.sejongpeer.domain.member.entity.Member;
+
 public record CompletedPartnerInfoResponse(
 	String collegeMajor,
 	Integer grade,
 	String name,
 	String kakaoAccount
 ) {
+	public static CompletedPartnerInfoResponse from(Member member) {
+		return new CompletedPartnerInfoResponse(
+			member.getCollegeMajor().getMajor(),
+			member.getGrade(),
+			member.getName(),
+			member.getKakaoAccount()
+		);
+	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/MatchingPartnerInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/MatchingPartnerInfoResponse.java
@@ -6,7 +6,7 @@ public record MatchingPartnerInfoResponse(
 	String collegeMajor,
 	Integer grade
 ) {
-	public static MatchingPartnerInfoResponse from(Member member) {
+	public static MatchingPartnerInfoResponse memberFrom(Member member) {
 		return new MatchingPartnerInfoResponse(
 			member.getCollegeMajor().getMajor(),
 			member.getGrade()

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/MatchingPartnerInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/MatchingPartnerInfoResponse.java
@@ -1,0 +1,15 @@
+package com.sejong.sejongpeer.domain.buddy.dto.response;
+
+import com.sejong.sejongpeer.domain.member.entity.Member;
+
+public record MatchingPartnerInfoResponse(
+	String collegeMajor,
+	Integer grade
+) {
+	public static MatchingPartnerInfoResponse from(Member member) {
+		return new MatchingPartnerInfoResponse(
+			member.getCollegeMajor().getMajor(),
+			member.getGrade()
+		);
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/PartnerInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/PartnerInfoResponse.java
@@ -1,0 +1,9 @@
+package com.sejong.sejongpeer.domain.buddy.dto.response;
+
+import com.sejong.sejongpeer.domain.college.entity.CollegeMajor;
+
+public record PartnerInfoResponse(
+	CollegeMajor collegeMajor,
+	Integer grade
+) {
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/PartnerInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/PartnerInfoResponse.java
@@ -1,9 +1,7 @@
 package com.sejong.sejongpeer.domain.buddy.dto.response;
 
-import com.sejong.sejongpeer.domain.college.entity.CollegeMajor;
-
 public record PartnerInfoResponse(
-	CollegeMajor collegeMajor,
+	String collegeMajor,
 	Integer grade
 ) {
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/PartnerInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/PartnerInfoResponse.java
@@ -1,7 +1,0 @@
-package com.sejong.sejongpeer.domain.buddy.dto.response;
-
-public record PartnerInfoResponse(
-	String collegeMajor,
-	Integer grade
-) {
-}

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
@@ -75,7 +75,11 @@ public class BuddyMatchingService {
 
 	public Buddy findTargetBuddy(Buddy ownerBuddy) {
 		Optional<BuddyMatched> optionalBuddyMatched = buddyMatchedRepository.findLatestByOwnerOrPartner(ownerBuddy);
-
-		return optionalBuddyMatched.map(BuddyMatched::getPartner).orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND));
+		BuddyMatched selectedBuddyMatched = optionalBuddyMatched.orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND));
+		if (selectedBuddyMatched.getOwner() == ownerBuddy) {
+			return selectedBuddyMatched.getPartner();
+		} else {
+			return selectedBuddyMatched.getOwner();
+		}
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
@@ -73,13 +73,22 @@ public class BuddyMatchingService {
 		targetBuddy.changeStatus(BuddyStatus.MATCHING_COMPLETED);
 	}
 
-	public Buddy findTargetBuddy(Buddy ownerBuddy) {
-		Optional<BuddyMatched> optionalBuddyMatched = buddyMatchedRepository.findLatestByOwnerOrPartner(ownerBuddy);
-		BuddyMatched selectedBuddyMatched = optionalBuddyMatched.orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND));
-		if (selectedBuddyMatched.getOwner() == ownerBuddy) {
-			return selectedBuddyMatched.getPartner();
+	private Buddy findTargetBuddy(Buddy ownerBuddy) {
+		BuddyMatched selectedBuddyMatched = getLatestBuddyMatched(ownerBuddy);
+
+		return getOtherBuddyInBuddyMatched(selectedBuddyMatched, ownerBuddy);
+	}
+
+	public BuddyMatched getLatestBuddyMatched(Buddy buddy) {
+		Optional<BuddyMatched> optionalBuddyMatched = buddyMatchedRepository.findLatestByOwnerOrPartner(buddy);
+		return  (optionalBuddyMatched.orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND)));
+	}
+
+	public   Buddy getOtherBuddyInBuddyMatched(BuddyMatched buddyMatched, Buddy ownerBuddy) {
+		if (buddyMatched.getOwner() == ownerBuddy) {
+			return buddyMatched.getPartner();
 		} else {
-			return selectedBuddyMatched.getOwner();
+			return buddyMatched.getOwner();
 		}
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
@@ -73,7 +73,7 @@ public class BuddyMatchingService {
 		targetBuddy.changeStatus(BuddyStatus.MATCHING_COMPLETED);
 	}
 
-	private Buddy findTargetBuddy(Buddy ownerBuddy) {
+	public Buddy findTargetBuddy(Buddy ownerBuddy) {
 		Optional<BuddyMatched> optionalBuddyMatched = buddyMatchedRepository.findLatestByOwnerOrPartner(ownerBuddy);
 
 		return optionalBuddyMatched.map(BuddyMatched::getPartner).orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND));

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -122,7 +122,7 @@ public class BuddyService {
 		Buddy partner =  buddyMatchingService.getOtherBuddyInBuddyMatched(latestBuddyMatched, latestBuddy);
 		Member partnerMember = partner.getMember();
 
-		return MatchingPartnerInfoResponse.from(partnerMember);
+		return MatchingPartnerInfoResponse.memberFrom(partnerMember);
 	}
 
 	public CompletedPartnerInfoResponse getBuddyMatchedPartnerDetails(String memberId) {
@@ -137,7 +137,7 @@ public class BuddyService {
 		Buddy partner =  buddyMatchingService.getOtherBuddyInBuddyMatched(latestBuddyMatched, latestBuddy);
 		Member partnerMember = partner.getMember();
 
-		return CompletedPartnerInfoResponse.from(partnerMember);
+		return CompletedPartnerInfoResponse.memberFrom(partnerMember);
 	}
 
 	private void checkBuddyStatus(Buddy buddy, BuddyStatus status) {

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -74,14 +74,22 @@ public class BuddyService {
 		Optional<Buddy> optionalBuddy = getLastBuddyByMemberId(memberId);
 
 		optionalBuddy.ifPresent(latestBuddy -> {
-			if (latestBuddy.getStatus() == BuddyStatus.IN_PROGRESS) {
-				throw new CustomException(ErrorCode.REGISTRATION_NOT_POSSIBLE);
-			}
-			if (latestBuddy.getStatus().equals(BuddyStatus.REJECT) &&
-				!isPossibleFromUpdateAt(latestBuddy.getUpdatedAt())) {
-				throw new CustomException(ErrorCode.REJECT_PENALTY);
-			}
+			checkInProgressStatus(latestBuddy);
+			checkRejectPenaltyAndUpdateStatus(latestBuddy);
 		});
+	}
+
+	private void checkInProgressStatus(Buddy buddy) {
+		if (buddy.getStatus() == BuddyStatus.IN_PROGRESS) {
+			throw new CustomException(ErrorCode.REGISTRATION_NOT_POSSIBLE);
+		}
+	}
+
+	private void checkRejectPenaltyAndUpdateStatus(Buddy buddy) {
+		if (buddy.getStatus().equals(BuddyStatus.REJECT) &&
+			!isPossibleFromUpdateAt(buddy.getUpdatedAt())) {
+			throw new CustomException(ErrorCode.REJECT_PENALTY);
+		}
 	}
 
 	private Optional<Buddy> getLastBuddyByMemberId(String memberId) {

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -112,7 +112,7 @@ public class BuddyService {
 
 		Member partnerMember = partner.getMember();
 
-		return (new PartnerInfoResponse(partnerMember.getCollegeMajor(), partnerMember.getGrade()));
+		return (new PartnerInfoResponse(partnerMember.getCollegeMajor().getMajor(), partnerMember.getGrade()));
 	}
 
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -10,7 +10,7 @@ import com.sejong.sejongpeer.domain.buddy.constant.LimitTimeConstant;
 import com.sejong.sejongpeer.domain.buddy.dto.request.RegisterRequest;
 import com.sejong.sejongpeer.domain.buddy.dto.response.CompletedPartnerInfoResponse;
 import com.sejong.sejongpeer.domain.buddy.dto.response.MatchingStatusResponse;
-import com.sejong.sejongpeer.domain.buddy.dto.response.PartnerInfoResponse;
+import com.sejong.sejongpeer.domain.buddy.dto.response.MatchingPartnerInfoResponse;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
 import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;
@@ -102,7 +102,7 @@ public class BuddyService {
 		return new MatchingStatusResponse(buddy.getStatus());
 	}
 
-	public PartnerInfoResponse getPartnerDetails(String memberId) {
+	public MatchingPartnerInfoResponse getPartnerDetails(String memberId) {
 
 		Buddy latestBuddy = getLastBuddyByMemberId(memberId)
 			.orElseThrow(() -> new CustomException(ErrorCode.BUDDY_NOT_FOUND));
@@ -114,10 +114,7 @@ public class BuddyService {
 		Buddy partner =  buddyMatchingService.getOtherBuddyInBuddyMatched(latestBuddyMatched, latestBuddy);
 		Member partnerMember = partner.getMember();
 
-		return (new PartnerInfoResponse(
-			partnerMember.getCollegeMajor().getMajor(),
-			partnerMember.getGrade()
-		));
+		return MatchingPartnerInfoResponse.from(partnerMember);
 	}
 
 	public CompletedPartnerInfoResponse getBuddyMatchedPartnerDetails(String memberId) {
@@ -132,12 +129,7 @@ public class BuddyService {
 		Buddy partner =  buddyMatchingService.getOtherBuddyInBuddyMatched(latestBuddyMatched, latestBuddy);
 		Member partnerMember = partner.getMember();
 
-		return (new CompletedPartnerInfoResponse(
-			partnerMember.getCollegeMajor().getMajor(),
-			partnerMember.getGrade(),
-			partnerMember.getName(),
-			partnerMember.getKakaoAccount()
-		));
+		return CompletedPartnerInfoResponse.from(partnerMember);
 	}
 
 	private void checkBuddyStatus(Buddy buddy, BuddyStatus status) {
@@ -151,9 +143,4 @@ public class BuddyService {
 			throw new CustomException(ErrorCode.NOT_IN_PROGRESS);
 		}
 	}
-
-
-
-
 }
-

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -8,10 +8,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.sejong.sejongpeer.domain.buddy.constant.LimitTimeConstant;
 import com.sejong.sejongpeer.domain.buddy.dto.request.RegisterRequest;
+import com.sejong.sejongpeer.domain.buddy.dto.response.CompletedPartnerInfoResponse;
 import com.sejong.sejongpeer.domain.buddy.dto.response.MatchingStatusResponse;
 import com.sejong.sejongpeer.domain.buddy.dto.response.PartnerInfoResponse;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
+import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;
+import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.type.BuddyMatchedStatus;
 import com.sejong.sejongpeer.domain.buddy.repository.BuddyRepository;
 import com.sejong.sejongpeer.domain.member.entity.Member;
 import com.sejong.sejongpeer.domain.member.repository.MemberRepository;
@@ -103,17 +106,54 @@ public class BuddyService {
 
 		Buddy latestBuddy = getLastBuddyByMemberId(memberId)
 			.orElseThrow(() -> new CustomException(ErrorCode.BUDDY_NOT_FOUND));
+		checkBuddyStatus(latestBuddy, BuddyStatus.FOUND_BUDDY);
 
-		if (latestBuddy.getStatus() != BuddyStatus.FOUND_BUDDY) {
-			throw new CustomException(ErrorCode.BUDDY_NOT_MATCHED);
-		}
+		BuddyMatched latestBuddyMatched = buddyMatchingService.getLatestBuddyMatched(latestBuddy);
+		checkBuddyMatchedStatus(latestBuddyMatched, BuddyMatchedStatus.IN_PROGRESS);
 
-		Buddy partner =  buddyMatchingService.findTargetBuddy(latestBuddy);
-
+		Buddy partner =  buddyMatchingService.getOtherBuddyInBuddyMatched(latestBuddyMatched, latestBuddy);
 		Member partnerMember = partner.getMember();
 
-		return (new PartnerInfoResponse(partnerMember.getCollegeMajor().getMajor(), partnerMember.getGrade()));
+		return (new PartnerInfoResponse(
+			partnerMember.getCollegeMajor().getMajor(),
+			partnerMember.getGrade()
+		));
 	}
+
+	public CompletedPartnerInfoResponse getBuddyMatchedPartnerDetails(String memberId) {
+
+		Buddy latestBuddy = getLastBuddyByMemberId(memberId)
+			.orElseThrow(() -> new CustomException(ErrorCode.BUDDY_NOT_FOUND));
+		checkBuddyStatus(latestBuddy, BuddyStatus.MATCHING_COMPLETED);
+
+		BuddyMatched latestBuddyMatched = buddyMatchingService.getLatestBuddyMatched(latestBuddy);
+		checkBuddyMatchedStatus(latestBuddyMatched, BuddyMatchedStatus.MATCHING_COMPLETED);
+
+		Buddy partner =  buddyMatchingService.getOtherBuddyInBuddyMatched(latestBuddyMatched, latestBuddy);
+		Member partnerMember = partner.getMember();
+
+		return (new CompletedPartnerInfoResponse(
+			partnerMember.getCollegeMajor().getMajor(),
+			partnerMember.getGrade(),
+			partnerMember.getName(),
+			partnerMember.getKakaoAccount()
+		));
+	}
+
+	private void checkBuddyStatus(Buddy buddy, BuddyStatus status) {
+		if (buddy.getStatus() != status) {
+			throw new CustomException(ErrorCode.BUDDY_NOT_MATCHED);
+		}
+	}
+
+	private void checkBuddyMatchedStatus(BuddyMatched buddyMatched, BuddyMatchedStatus status) {
+		if (buddyMatched.getStatus() != status) {
+			throw new CustomException(ErrorCode.NOT_IN_PROGRESS);
+		}
+	}
+
+
+
 
 }
 

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.sejong.sejongpeer.domain.buddy.constant.LimitTimeConstant;
 import com.sejong.sejongpeer.domain.buddy.dto.request.RegisterRequest;
 import com.sejong.sejongpeer.domain.buddy.dto.response.MatchingStatusResponse;
+import com.sejong.sejongpeer.domain.buddy.dto.response.PartnerInfoResponse;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
 import com.sejong.sejongpeer.domain.buddy.repository.BuddyRepository;
@@ -97,5 +98,22 @@ public class BuddyService {
 
 		return new MatchingStatusResponse(buddy.getStatus());
 	}
+
+	public PartnerInfoResponse getPartnerDetails(String memberId) {
+
+		Buddy latestBuddy = getLastBuddyByMemberId(memberId)
+			.orElseThrow(() -> new CustomException(ErrorCode.BUDDY_NOT_FOUND));
+
+		if (latestBuddy.getStatus() != BuddyStatus.FOUND_BUDDY) {
+			throw new CustomException(ErrorCode.BUDDY_NOT_MATCHED);
+		}
+
+		Buddy partner =  buddyMatchingService.findTargetBuddy(latestBuddy);
+
+		Member partnerMember = partner.getMember();
+
+		return (new PartnerInfoResponse(partnerMember.getCollegeMajor(), partnerMember.getGrade()));
+	}
+
 }
 

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -44,14 +44,15 @@ public enum ErrorCode {
     NOT_IN_PROGRESS(HttpStatus.CONFLICT, "버디 매칭중이 아닙니다."),
     REGISTRATION_NOT_POSSIBLE(HttpStatus.CONFLICT, "버디 신청을 할 수 없습니다."),
     TARGET_BUDDY_NOT_FOUND(HttpStatus.NOT_FOUND, "상대 버디를 찾을 수 없습니다."),
+    BUDDY_NOT_MATCHED(HttpStatus.CONFLICT, "매칭 성사된 버디가 아닙니다."),
 
     // Study
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
 
-	// 버디 등록 거절
-	REJECT_PENALTY(HttpStatus.FORBIDDEN, "짝매칭 이후 거절한 유저는 1시간 동안 버디를 등록할 수 없습니다.");
+    // 버디 등록 거절
+    REJECT_PENALTY(HttpStatus.FORBIDDEN, "짝매칭 이후 거절한 유저는 24시간 동안 버디를 등록할 수 없습니다.");
     private final HttpStatus status;
     private final String message;
 
-
 }
+


### PR DESCRIPTION
## 🌱 관련 이슈
- #73 

## 📌 작업 내용 및 특이사항
- 버디 매칭 후 상대방 정보 요청
- 버디 매칭 수락 완료 후 상대방 정보 요청
- BuddyMatchingService에 findTargetBuddy 공통으로 쓰이는 함수 리펙토링

## 📝 참고사항
- BuddyService에서 BuddyMatchingServiced의 함수를 쓰려고
- '''private final MatchingService matchingService;
	private final BuddyRepository buddyRepository;
	private final MemberRepository memberRepository;
	private final BuddyMatchingService buddyMatchingService;''' 이런식으로 

buddyService에서 BuddyMatchingService를 불러와서 사용을 했는데 더 좋은 방법이 있을까요,,?  
찾아보니 나중에 서로 참조를 하게 되는 경우가 생기면 순환참조 문제가 발생할 수 있다고 하긴하는데 다른 방법을 찾지못해서 여쭤봅니다!

## 📚 기타
- 
