### PR TITLE
✨ 혼밥 짝꿍 매칭 성공 시 상대방 정보 제공

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/api/HonbabController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/api/HonbabController.java
@@ -1,0 +1,28 @@
+package com.sejong.sejongpeer.domain.honbab.api;
+
+import com.sejong.sejongpeer.domain.honbab.dto.response.MatchingPartnerInfoResponse;
+import com.sejong.sejongpeer.domain.honbab.service.HonbabService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+@Tag(name = "6. [혼밥]", description = "세종혼밥짝꿍 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/honbab")
+public class HonbabController {
+
+	private final HonbabService honbabService;
+
+	@Operation(summary = "혼밥짝꿍 찾은 후 상대방 정보 요청", description = "매칭 후 상대방의 정보 반환")
+	@GetMapping("/partner/information")
+	public MatchingPartnerInfoResponse getFoundPartnerInfo() {
+		String memberId = (String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		return honbabService.getPartnerInfo(memberId);
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/dto/response/MatchingPartnerInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/dto/response/MatchingPartnerInfoResponse.java
@@ -1,0 +1,18 @@
+package com.sejong.sejongpeer.domain.honbab.dto.response;
+
+import com.sejong.sejongpeer.domain.honbab.entity.honbab.Honbab;
+import com.sejong.sejongpeer.domain.member.entity.Member;
+
+public record MatchingPartnerInfoResponse(
+	String collegeMajor,
+	Integer grade,
+	String name,
+	String kakaoAccount,
+	String menuCategoryOption
+) {
+
+	public static MatchingPartnerInfoResponse of(Member member, Honbab honbab) {
+		return new MatchingPartnerInfoResponse(member.getCollegeMajor().getMajor(),
+			member.getGrade(), member.getName(), member.getKakaoAccount(), honbab.getMenuCategoryOption().toString());
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/repository/HonbabMatchedRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/repository/HonbabMatchedRepository.java
@@ -1,8 +1,16 @@
 package com.sejong.sejongpeer.domain.honbab.repository;
 
+import com.sejong.sejongpeer.domain.honbab.entity.honbab.Honbab;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sejong.sejongpeer.domain.honbab.entity.honbabmatched.HonbabMatched;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface HonbabMatchedRepository extends JpaRepository<HonbabMatched, Long> {
+
+	@Query("SELECT bm FROM HonbabMatched bm WHERE bm.owner = :owner OR bm.partner = :owner ORDER BY bm.id DESC LIMIT 1")
+	Optional<HonbabMatched> findLatestByOwnerOrPartner(@Param("owner") Honbab owner);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/repository/HonbabRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/repository/HonbabRepository.java
@@ -1,12 +1,18 @@
 package com.sejong.sejongpeer.domain.honbab.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sejong.sejongpeer.domain.honbab.entity.honbab.Honbab;
 import com.sejong.sejongpeer.domain.honbab.entity.honbab.type.HonbabStatus;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface HonbabRepository extends JpaRepository<Honbab, Long> {
 	List<Honbab> findAllByStatus(HonbabStatus status);
+
+	@Query("SELECT b FROM Honbab b WHERE b.member.id = :memberId ORDER BY b.id DESC LIMIT 1")
+	Optional<Honbab> findLastHonbabByMemberId(@Param("memberId") String memberId);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/service/HonbabService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/service/HonbabService.java
@@ -1,0 +1,51 @@
+package com.sejong.sejongpeer.domain.honbab.service;
+
+import com.sejong.sejongpeer.domain.honbab.dto.response.MatchingPartnerInfoResponse;
+import com.sejong.sejongpeer.domain.honbab.entity.honbab.Honbab;
+import com.sejong.sejongpeer.domain.honbab.entity.honbabmatched.HonbabMatched;
+import com.sejong.sejongpeer.domain.honbab.repository.HonbabMatchedRepository;
+import com.sejong.sejongpeer.domain.honbab.repository.HonbabRepository;
+import com.sejong.sejongpeer.domain.member.entity.Member;
+import com.sejong.sejongpeer.global.error.exception.CustomException;
+import com.sejong.sejongpeer.global.error.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HonbabService {
+
+	private final HonbabRepository honbabRepository;
+	private final HonbabMatchedRepository honbabMatchedRepository;
+
+	public MatchingPartnerInfoResponse getPartnerInfo(String memberId) {
+
+		Honbab lastestHonbab = getLastestHonbabByMemberId(memberId).orElseThrow(() -> new CustomException(ErrorCode.HONBAB_NOT_FOUND));
+		HonbabMatched selectedHonbabMatched = getLastestHonbabMatchedByHonbab(lastestHonbab).orElseThrow(() -> new CustomException(ErrorCode.TARGET_HONBAB_NOT_FOUND));
+		Honbab targetHonbab = getHonbabFriend(selectedHonbabMatched, lastestHonbab);
+		Member targetHonbabMember = targetHonbab.getMember();
+
+		return MatchingPartnerInfoResponse.of(targetHonbabMember, targetHonbab);
+
+	}
+
+	private Optional<Honbab> getLastestHonbabByMemberId(String memberId) {
+		return honbabRepository.findLastHonbabByMemberId(memberId);
+	}
+
+	private Optional<HonbabMatched> getLastestHonbabMatchedByHonbab(Honbab applicant) {
+		// 만들어진 HonbabMatched의 status는 항상 MATCHING_COMPLETED
+		return honbabMatchedRepository.findLatestByOwnerOrPartner(applicant);
+	}
+
+	private Honbab getHonbabFriend(HonbabMatched selectedMatched, Honbab applicant) {
+		if (selectedMatched.getOwner() == applicant) {
+			return selectedMatched.getPartner();
+		}
+		return selectedMatched.getOwner();
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -49,15 +49,11 @@ public enum ErrorCode {
     // Study
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
 
-    // 혼밥 에러
-    HONBAB_NOT_FOUND(HttpStatus.NOT_FOUND, "신청한 혼밥이 없습니다"),
-
-
 	// 버디 등록 거절
 	REJECT_PENALTY(HttpStatus.FORBIDDEN, "짝매칭 이후 거절한 유저는 1시간 동안 버디를 등록할 수 없습니다."),
 
 	// 혼밥 에러
-	HONBAB_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 혼밥 짝꿍이 없습니다"),
+	HONBAB_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 혼밥이 없습니다"),
 	TARGET_HONBAB_NOT_FOUND(HttpStatus.NOT_FOUND, "혼밥 짝꿍을 찾을 수 없습니다.");
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -49,7 +49,11 @@ public enum ErrorCode {
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
 
 	// 버디 등록 거절
-	REJECT_PENALTY(HttpStatus.FORBIDDEN, "짝매칭 이후 거절한 유저는 1시간 동안 버디를 등록할 수 없습니다.");
+	REJECT_PENALTY(HttpStatus.FORBIDDEN, "짝매칭 이후 거절한 유저는 1시간 동안 버디를 등록할 수 없습니다."),
+
+	// 혼밥 에러
+	HONBAB_NOT_FOUND(HttpStatus.NOT_FOUND, "등록된 혼밥 짝꿍이 없습니다"),
+	TARGET_HONBAB_NOT_FOUND(HttpStatus.NOT_FOUND, "혼밥 짝꿍을 찾을 수 없습니다.");
     private final HttpStatus status;
     private final String message;
 

--- a/src/main/java/com/sejong/sejongpeer/infra/sms/service/SmsText.java
+++ b/src/main/java/com/sejong/sejongpeer/infra/sms/service/SmsText.java
@@ -5,7 +5,8 @@ public enum SmsText {
 		+ "혼밥탈출에 다시 접속해 밥짝꿍의 정보를 확인해주세요:)"),
 	MATCHING_FOUND_BUDDY("[세종피어] 버디를 찾았습니다! \n"
 		+ "세종버디에 재접속해 버디정보(학과, 학년) 확인 후 수락여부를 결정해주세요."),
-	MATCHING_COMPLETE_BUDDY("[세종피어] 버디 매칭에 성공했습니다! 혼밥탈출에 다시 접속해 밥짝꿍의 정보를 확인해주세요:)");
+	MATCHING_COMPLETE_BUDDY("[세종피어]버디 매칭에 성공했습니다!\n" +
+		"세종버디에 다시 접속해 버디의 정보를 모두 확인해주세요 :)");
 
 	private final String value;
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #80 

## 📌 작업 내용 및 특이사항
- 피그마 상에서 이전의 버디 매칭과 달리 프론트분들께 받는 거절/수락 기능이 없기 때문에 혼밥 매칭 상대를 찾았을 경우 바로 상대 정보를 반환합니다.

## 📝 참고사항
- 버디 선후배 짝매칭 성공 시 발송되는 문자 내용 추가로 수정했습니다.

## 📚 기타
- 
