### PR TITLE
🐛 유저의 버디 엔티티를 찾을 때 찾는 상태를 FOUNDED_BUDDY로 변경

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
@@ -33,7 +33,7 @@ public class BuddyMatchingService {
 	public void updateBuddyMatchingStatus(String memberId, MatchingResultRequest request) {
 		Member owner = getMemberById(memberId);
 
-		Optional<Buddy> optionalOwnerLatestBuddy = buddyRepository.findTopByMemberAndStatusOrderByCreatedAtDesc(owner, BuddyStatus.IN_PROGRESS);
+		Optional<Buddy> optionalOwnerLatestBuddy = buddyRepository.findTopByMemberAndStatusOrderByCreatedAtDesc(owner, BuddyStatus.FOUND_BUDDY);
 		Buddy ownerLatestBuddy = optionalOwnerLatestBuddy.orElseThrow(() -> new CustomException(ErrorCode.BUDDY_NOT_FOUND));
 
 		if (request.isAccept()) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #106 

## 📌 작업 내용 및 특이사항
- 버디를 찾았으나 등록된 버디가 없다는 response에 대한 수정

## 📝 참고사항
- 

## 📚 기타
- 
