### PR TITLE
:bug: 회원탈퇴 버그 수정

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/entity/buddy/Buddy.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/entity/buddy/Buddy.java
@@ -2,14 +2,16 @@ package com.sejong.sejongpeer.domain.buddy.entity.buddy;
 
 import org.hibernate.annotations.Comment;
 
+import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.ClassTypeOption;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.CollegeMajorOption;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.GenderOption;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.GradeOption;
-import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
+import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;
 import com.sejong.sejongpeer.domain.common.BaseAuditEntity;
 import com.sejong.sejongpeer.domain.member.entity.Member;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -20,6 +22,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -66,6 +69,12 @@ public class Buddy extends BaseAuditEntity {
 	@Comment("복수전공 확인")
 	@Column(nullable = false)
 	private boolean isSubMajor;
+
+	@OneToOne(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
+	private BuddyMatched matchedAsOwner;
+
+	@OneToOne(mappedBy = "partner", cascade = CascadeType.ALL, orphanRemoval = true)
+	private BuddyMatched matchedAsPartner;
 
 	@Builder(access = AccessLevel.PRIVATE)
 	private Buddy(

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/entity/buddymatched/BuddyMatched.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/entity/buddymatched/BuddyMatched.java
@@ -30,11 +30,11 @@ public class BuddyMatched extends BaseAuditEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
 	@JoinColumn(name = "owner")
 	private Buddy owner;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
 	@JoinColumn(name = "partner")
 	private Buddy partner;
 

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/entity/honbab/Honbab.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/entity/honbab/Honbab.java
@@ -5,8 +5,10 @@ import com.sejong.sejongpeer.domain.honbab.dto.request.RegisterHonbabRequest;
 import com.sejong.sejongpeer.domain.honbab.entity.honbab.type.GenderOption;
 import com.sejong.sejongpeer.domain.honbab.entity.honbab.type.HonbabStatus;
 import com.sejong.sejongpeer.domain.honbab.entity.honbab.type.MenuCategoryOption;
+import com.sejong.sejongpeer.domain.honbab.entity.honbabmatched.HonbabMatched;
 import com.sejong.sejongpeer.domain.member.entity.Member;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -15,11 +17,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 
 @Entity
 @Getter
@@ -41,6 +43,12 @@ public class Honbab extends BaseAuditEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Member member;
 
+	@OneToOne(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
+	private HonbabMatched matchedAsOwner;
+
+	@OneToOne(mappedBy = "partner", cascade = CascadeType.ALL, orphanRemoval = true)
+	private HonbabMatched matchedAsPartner;
+
 	@Builder(access = AccessLevel.PRIVATE)
 	private Honbab(
 		Member member,
@@ -53,6 +61,7 @@ public class Honbab extends BaseAuditEntity {
 		this.genderOption = genderOption;
 		this.menuCategoryOption = menuCategoryOption;
 	}
+
 	public static Honbab createHonbab(
 		Member member,
 		RegisterHonbabRequest request) {
@@ -63,6 +72,7 @@ public class Honbab extends BaseAuditEntity {
 			.menuCategoryOption(request.menuCategoryOption())
 			.build();
 	}
+
 	public void changeStatus(HonbabStatus status) {
 		this.status = status;
 	}

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/entity/honbabmatched/HonbabMatched.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/entity/honbabmatched/HonbabMatched.java
@@ -29,11 +29,11 @@ public class HonbabMatched extends BaseAuditEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
 	@JoinColumn(name = "owner")
 	private Honbab owner;
 
-	@OneToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
 	@JoinColumn(name = "partner")
 	private Honbab partner;
 

--- a/src/main/java/com/sejong/sejongpeer/domain/member/entity/Member.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/member/entity/Member.java
@@ -1,12 +1,19 @@
 package com.sejong.sejongpeer.domain.member.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.UuidGenerator;
+
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
 import com.sejong.sejongpeer.domain.college.entity.CollegeMajor;
 import com.sejong.sejongpeer.domain.common.BaseAuditEntity;
+import com.sejong.sejongpeer.domain.honbab.entity.honbab.Honbab;
 import com.sejong.sejongpeer.domain.member.dto.request.SignUpRequest;
 import com.sejong.sejongpeer.domain.member.entity.type.Gender;
 import com.sejong.sejongpeer.domain.member.entity.type.Status;
 import com.sejong.sejongpeer.domain.study.entity.Study;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,126 +23,126 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.UuidGenerator;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class Member extends BaseAuditEntity {
-    @Id
-    @UuidGenerator
-    @Column(name = "id", columnDefinition = "char(36)")
-    private String id;
+	@Id
+	@UuidGenerator
+	@Column(name = "id", columnDefinition = "char(36)")
+	private String id;
 
-    @Column(columnDefinition = "varchar(20)", nullable = false, unique = true)
-    private String account;
+	@Column(columnDefinition = "varchar(20)", nullable = false, unique = true)
+	private String account;
 
-    @Column(columnDefinition = "varchar(70)", nullable = false)
-    private String password;
+	@Column(columnDefinition = "varchar(70)", nullable = false)
+	private String password;
 
-    @Column(columnDefinition = "varchar(10)", nullable = false, unique = true)
-    private String nickname;
+	@Column(columnDefinition = "varchar(10)", nullable = false, unique = true)
+	private String nickname;
 
-    @Column(columnDefinition = "varchar(50)", nullable = false, unique = true)
-    private String kakaoAccount;
+	@Column(columnDefinition = "varchar(50)", nullable = false, unique = true)
+	private String kakaoAccount;
 
-    @Column(columnDefinition = "varchar(40)", nullable = false)
-    private String name;
+	@Column(columnDefinition = "varchar(40)", nullable = false)
+	private String name;
 
-    @Column(columnDefinition = "varchar(30)", nullable = false)
-    private String phoneNumber;
+	@Column(columnDefinition = "varchar(30)", nullable = false)
+	private String phoneNumber;
 
-    @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "enum('MALE', 'FEMALE')", nullable = false)
-    private Gender gender;
+	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "enum('MALE', 'FEMALE')", nullable = false)
+	private Gender gender;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private CollegeMajor collegeMajor;
+	@ManyToOne(fetch = FetchType.LAZY)
+	private CollegeMajor collegeMajor;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private CollegeMajor collegeMinor; // 부전공 혹은 복수전공
+	@ManyToOne(fetch = FetchType.LAZY)
+	private CollegeMajor collegeMinor; // 부전공 혹은 복수전공
 
-    @Column(columnDefinition = "int", nullable = false)
-    private Integer grade;
+	@Column(columnDefinition = "int", nullable = false)
+	private Integer grade;
 
-    @Column(columnDefinition = "varchar(10)", nullable = false)
-    private String studentId;
+	@Column(columnDefinition = "varchar(10)", nullable = false)
+	private String studentId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "enum('ACTIVE', 'BLOCKED')", nullable = false)
-    private Status status;
+	@Enumerated(EnumType.STRING)
+	@Column(columnDefinition = "enum('ACTIVE', 'BLOCKED')", nullable = false)
+	private Status status;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Study> studies = new ArrayList<>();
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Study> studies = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Buddy> buddies = new ArrayList<>();
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Buddy> buddies = new ArrayList<>();
 
-    @Builder
-    private Member(
-            String account,
-            String password,
-            String name,
-            String nickname,
-            String phoneNumber,
-            Gender gender,
-            CollegeMajor collegeMajor,
-            CollegeMajor collegeMinor,
-            Integer grade,
-            String studentId,
-            String kakaoAccount) {
-        this.account = account;
-        this.password = password;
-        this.name = name;
-        this.nickname = nickname;
-        this.phoneNumber = phoneNumber;
-        this.kakaoAccount = kakaoAccount;
-        this.collegeMinor = collegeMinor;
-        this.collegeMajor = collegeMajor;
-        this.gender = gender;
-        this.grade = grade;
-        this.studentId = studentId;
-        this.status = Status.ACTIVE;
-    }
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Honbab> honbabs = new ArrayList<>();
 
-    public static Member create(
-            SignUpRequest request,
-            CollegeMajor collegeMajor,
-            CollegeMajor collegeMinor,
-            String encodedPassword) {
-        return Member.builder()
-                .name(request.name())
-                .collegeMajor(collegeMajor)
-                .collegeMinor(collegeMinor)
-                .grade(request.grade())
-                .phoneNumber(request.phoneNumber())
-                .account(request.account())
-                .password(encodedPassword)
-                .gender(request.gender())
-                .studentId(request.studentId())
-                .kakaoAccount(request.kakaoAccount())
-                .nickname(request.nickname())
-                .build();
-    }
+	@Builder
+	private Member(
+		String account,
+		String password,
+		String name,
+		String nickname,
+		String phoneNumber,
+		Gender gender,
+		CollegeMajor collegeMajor,
+		CollegeMajor collegeMinor,
+		Integer grade,
+		String studentId,
+		String kakaoAccount) {
+		this.account = account;
+		this.password = password;
+		this.name = name;
+		this.nickname = nickname;
+		this.phoneNumber = phoneNumber;
+		this.kakaoAccount = kakaoAccount;
+		this.collegeMinor = collegeMinor;
+		this.collegeMajor = collegeMajor;
+		this.gender = gender;
+		this.grade = grade;
+		this.studentId = studentId;
+		this.status = Status.ACTIVE;
+	}
 
-    public void changeNickname(String nickname) {
-        this.nickname = nickname;
-    }
+	public static Member create(
+		SignUpRequest request,
+		CollegeMajor collegeMajor,
+		CollegeMajor collegeMinor,
+		String encodedPassword) {
+		return Member.builder()
+			.name(request.name())
+			.collegeMajor(collegeMajor)
+			.collegeMinor(collegeMinor)
+			.grade(request.grade())
+			.phoneNumber(request.phoneNumber())
+			.account(request.account())
+			.password(encodedPassword)
+			.gender(request.gender())
+			.studentId(request.studentId())
+			.kakaoAccount(request.kakaoAccount())
+			.nickname(request.nickname())
+			.build();
+	}
 
-    public void changePassword(String encryptedPassword) {
-        this.password = encryptedPassword;
-    }
+	public void changeNickname(String nickname) {
+		this.nickname = nickname;
+	}
 
-    public void changePhoneNumber(String phoneNumber) {
-        this.phoneNumber = phoneNumber;
-    }
+	public void changePassword(String encryptedPassword) {
+		this.password = encryptedPassword;
+	}
 
-    public void changeKakaoAccount(String kakaoAccount) {
-        this.kakaoAccount = kakaoAccount;
-    }
+	public void changePhoneNumber(String phoneNumber) {
+		this.phoneNumber = phoneNumber;
+	}
+
+	public void changeKakaoAccount(String kakaoAccount) {
+		this.kakaoAccount = kakaoAccount;
+	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- #110 

## 📌 작업 내용 및 특이사항
- cascade 옵션과 orphanRemoval을 사용해, member 삭제시 연관된 엔티티가 전부 삭제되도록 수정하였습니다.
- buddyMatched, honbabMatched의 상대편 buddy, honbab 신청내역도 삭제되는 로직입니다. 추후 문제가 있다고 판단되면 다른 방식으로 상대편의 상태를 변경하는 로직으로 변경해야 할 것 같습니다.

## 📝 참고사항
- 

## 📚 기타
- 
