### PR TITLE
✨ 혼밥 매칭 후 재신청 가능한 상태 추가 및 상태 체크 시 업데이트

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/entity/honbab/type/HonbabStatus.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/entity/honbab/type/HonbabStatus.java
@@ -8,7 +8,8 @@ public enum HonbabStatus {
 	IN_PROGRESS("매칭 중"),
 	CANCEL("중도 취소"),
 	MATCHING_COMPLETED("매칭 성사"),
-	TIME_OUT("시간 초과");
+	TIME_OUT("시간 초과"),
+	EXPIRED("재신청 가능");
 
 	private final String value;
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #123 

## 📌 작업 내용 및 특이사항
- 프론트에서 매칭 페이지로 넘어가는 조건에 null, time out 뿐만 아니라 expired 상태 추가해주시면 될 것 같습니다 

## 📝 참고사항
- postman으로 테스트 완료하였고 matching completed이후 15분 지났을 경우 상태 체크 api에서 expired를 반환합니다

## 📚 기타
- 
