### PR TITLE
✨ 버디 양쪽 모두 매칭 수락 이후 모든 상대 정보 반환 기능 추가

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @Tag(name = "4. [버디]", description = "세종버디 API")
 @RestController
 @RequiredArgsConstructor
@@ -58,7 +60,7 @@ public class BuddyController {
 
 	@Operation(summary = "매칭 수락 완료 후 상대방 정보요청", description = "이름, 학년, 학과, 카카오톡 정보 리턴")
 	@GetMapping("/matched/partner/details")
-	public CompletedPartnerInfoResponse getBuddyMatchedPartnerDetails() {
+	public List<CompletedPartnerInfoResponse> getBuddyMatchedPartnerDetails() {
 		String memberId =
 			(String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		return buddyService.getBuddyMatchedPartnerDetails(memberId);

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
@@ -7,6 +7,7 @@ import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BuddyMatchedRepository extends JpaRepository<BuddyMatched, Long> {
@@ -18,4 +19,9 @@ public interface BuddyMatchedRepository extends JpaRepository<BuddyMatched, Long
         "AND bm.owner IS NOT NULL AND bm.partner IS NOT NULL")
 	Optional<BuddyMatched> findByOwnerAndPartner(@Param("owner") Buddy owner, @Param("partner") Buddy partner);
 
+	@Query("SELECT bm FROM BuddyMatched bm WHERE " +
+		"(:owner = bm.owner OR :owner = bm.partner) " +
+		"AND bm.status = 'MATCHING_COMPLETED' " +
+		"ORDER BY bm.id DESC LIMIT 1")
+	Optional<BuddyMatched> findLatestByOwnerOrPartnerAndStatus(@Param("owner") Buddy owner);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
@@ -1,6 +1,7 @@
 package com.sejong.sejongpeer.domain.buddy.repository;
 
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
+import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.type.BuddyMatchedStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;
@@ -21,7 +22,7 @@ public interface BuddyMatchedRepository extends JpaRepository<BuddyMatched, Long
 
 	@Query("SELECT bm FROM BuddyMatched bm WHERE " +
 		"(:owner = bm.owner OR :owner = bm.partner) " +
-		"AND bm.status = 'MATCHING_COMPLETED' " +
+		"AND bm.status = :status " +
 		"ORDER BY bm.id DESC LIMIT 1")
-	Optional<BuddyMatched> findLatestByOwnerOrPartnerAndStatus(@Param("owner") Buddy owner);
+	Optional<BuddyMatched> findLatestByOwnerOrPartnerAndStatus(@Param("owner") Buddy owner, @Param("status") BuddyMatchedStatus status);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
@@ -22,7 +22,6 @@ public interface BuddyMatchedRepository extends JpaRepository<BuddyMatched, Long
 
 	@Query("SELECT bm FROM BuddyMatched bm WHERE " +
 		"(:owner = bm.owner OR :owner = bm.partner) " +
-		"AND bm.status = :status " +
-		"ORDER BY bm.id DESC LIMIT 1")
+		"AND bm.status = :status" )
 	Optional<BuddyMatched> findLatestByOwnerOrPartnerAndStatus(@Param("owner") Buddy owner, @Param("status") BuddyMatchedStatus status);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
@@ -21,7 +21,7 @@ public interface BuddyMatchedRepository extends JpaRepository<BuddyMatched, Long
 	Optional<BuddyMatched> findByOwnerAndPartner(@Param("owner") Buddy owner, @Param("partner") Buddy partner);
 
 	@Query("SELECT bm FROM BuddyMatched bm WHERE " +
-		"(:owner = bm.owner OR :owner = bm.partner) " +
-		"AND bm.status = :status" )
-	Optional<BuddyMatched> findLatestByOwnerOrPartnerAndStatus(@Param("owner") Buddy owner, @Param("status") BuddyMatchedStatus status);
+		"(:owner = bm.owner OR :owner = bm.partner)")
+	Optional<BuddyMatched> findByOwnerOrPartner(@Param("owner") Buddy owner);
+
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyRepository.java
@@ -21,4 +21,6 @@ public interface BuddyRepository extends JpaRepository<Buddy, Long> {
 
 	@Query("SELECT COUNT(b) FROM Buddy b WHERE b.status = 'IN_PROGRESS' OR b.status = 'FOUND_BUDDY'")
 	Long countByStatusInProgressOrFoundBuddy();
+
+	Optional<List<Buddy>> findAllByMemberIdAndStatus(String memberId, BuddyStatus status);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyRepository.java
@@ -22,5 +22,5 @@ public interface BuddyRepository extends JpaRepository<Buddy, Long> {
 	@Query("SELECT COUNT(b) FROM Buddy b WHERE b.status = 'IN_PROGRESS' OR b.status = 'FOUND_BUDDY'")
 	Long countByStatusInProgressOrFoundBuddy();
 
-	Optional<List<Buddy>> findAllByMemberIdAndStatus(String memberId, BuddyStatus status);
+	List<Buddy> findAllByMemberIdAndStatus(String memberId, BuddyStatus status);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -140,7 +140,7 @@ public class BuddyService {
 
 		return completedBuddies.stream()
 			.map(buddy -> {
-				BuddyMatched completedBuddyMatched = buddyMatchedRepository.findLatestByOwnerOrPartnerAndStatus(buddy, BuddyMatchedStatus.MATCHING_COMPLETED)
+				BuddyMatched completedBuddyMatched = buddyMatchedRepository.findByOwnerOrPartner(buddy)
 					.orElseThrow(() -> new CustomException(ErrorCode.BUDDY_NOT_MATCHED));
 
 				Buddy partner = buddyMatchingService.getOtherBuddyInBuddyMatched(completedBuddyMatched, buddy);

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -138,15 +138,10 @@ public class BuddyService {
 		List<Buddy> completedBuddies = buddyRepository.findAllByMemberIdAndStatus(memberId, BuddyStatus.MATCHING_COMPLETED);
 		checkCompletedBuddies(completedBuddies);
 
-		for (Buddy buddy : completedBuddies) { // 내가 신청한 버디
-			System.out.println(buddy.getId());
-		}
-
 		return completedBuddies.stream()
 			.map(buddy -> {
 				BuddyMatched completedBuddyMatched = buddyMatchedRepository.findLatestByOwnerOrPartnerAndStatus(buddy, BuddyMatchedStatus.MATCHING_COMPLETED)
 					.orElseThrow(() -> new CustomException(ErrorCode.BUDDY_NOT_MATCHED));
-				System.out.println(completedBuddyMatched.getId());
 
 				Buddy partner = buddyMatchingService.getOtherBuddyInBuddyMatched(completedBuddyMatched, buddy);
 				Member partnerMember = partner.getMember();

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -135,13 +135,18 @@ public class BuddyService {
 
 	public List<CompletedPartnerInfoResponse> getBuddyMatchedPartnerDetails(String memberId) {
 
-		List<Buddy> completedBuddies = buddyRepository.findAllByMemberIdAndStatus(memberId, BuddyStatus.MATCHING_COMPLETED)
-			.orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND));
+		List<Buddy> completedBuddies = buddyRepository.findAllByMemberIdAndStatus(memberId, BuddyStatus.MATCHING_COMPLETED);
+		if (completedBuddies.isEmpty())
+			throw new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND);
+		for (Buddy buddy : completedBuddies) { // 내가 신청한 버디
+			System.out.println(buddy.getId());
+		}
 
 		return completedBuddies.stream()
 			.map(buddy -> {
 				BuddyMatched completedBuddyMatched = buddyMatchedRepository.findLatestByOwnerOrPartnerAndStatus(buddy)
 					.orElseThrow(() -> new CustomException(ErrorCode.BUDDY_NOT_MATCHED));
+				System.out.println(completedBuddyMatched.getId());
 
 				Buddy partner = buddyMatchingService.getOtherBuddyInBuddyMatched(completedBuddyMatched, buddy);
 				Member partnerMember = partner.getMember();

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -136,8 +136,8 @@ public class BuddyService {
 	public List<CompletedPartnerInfoResponse> getBuddyMatchedPartnerDetails(String memberId) {
 
 		List<Buddy> completedBuddies = buddyRepository.findAllByMemberIdAndStatus(memberId, BuddyStatus.MATCHING_COMPLETED);
-		if (completedBuddies.isEmpty())
-			throw new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND);
+		checkCompletedBuddies(completedBuddies);
+
 		for (Buddy buddy : completedBuddies) { // 내가 신청한 버디
 			System.out.println(buddy.getId());
 		}
@@ -165,6 +165,11 @@ public class BuddyService {
 		if (buddyMatched.getStatus() != status) {
 			throw new CustomException(ErrorCode.NOT_IN_PROGRESS);
 		}
+	}
+
+	private void checkCompletedBuddies(List<Buddy> completedBuddies) {
+		if (completedBuddies.isEmpty())
+			throw new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND);
 	}
 
 	public ActiveCustomersCountResponse getCurrentlyActiveBuddyCount() {

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -144,7 +144,7 @@ public class BuddyService {
 
 		return completedBuddies.stream()
 			.map(buddy -> {
-				BuddyMatched completedBuddyMatched = buddyMatchedRepository.findLatestByOwnerOrPartnerAndStatus(buddy)
+				BuddyMatched completedBuddyMatched = buddyMatchedRepository.findLatestByOwnerOrPartnerAndStatus(buddy, BuddyMatchedStatus.MATCHING_COMPLETED)
 					.orElseThrow(() -> new CustomException(ErrorCode.BUDDY_NOT_MATCHED));
 				System.out.println(completedBuddyMatched.getId());
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #135 

## 📌 작업 내용 및 특이사항
- 최종적인 컨트롤러의 response를 List 형식의 반환으로 수정했습니다
- 서로 다른 유저 두 명 모두가 모두 수락을 한 이후 호출되는 api라는 점을 고려해서 buddyRepository에서 한 유저에 대해 MATCHING_COMPLETED인 Buddy를 모두 찾아 list에 저장하고 
- 특정 유저의 위에서 언급한 list 내 각 버디에 대해 buddyMatchedRepository로 BuddyMatched를 찾아
- 위의 BuddyMatched에서 partner(otherBuddy)의 정보를 반환하는 로직입니다

## 📝 참고사항
- postman으로 DB에 계정 추가해서 매칭 된 버디가 한 명뿐일 때와 여러명일 때 모두 상대 유저 정보 response 확인했습니다.

## 📚 기타
- 
