### PR TITLE
🐛 REJECT상태인 버디 등록 시 상태값 반환에서 처리

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/entity/buddy/type/BuddyStatus.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/entity/buddy/type/BuddyStatus.java
@@ -12,6 +12,7 @@ public enum BuddyStatus {
     REJECT("거절"),
     DENIED("거절당함"),
     FOUND_BUDDY("상대 찾음"),
-    MATCHING_COMPLETED("매칭 성사");
+    MATCHING_COMPLETED("매칭 성사"),
+    REACTIVATE("재신청 가능");
     private final String value;
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -103,15 +103,23 @@ public class BuddyService {
 		return LocalDateTime.now().isAfter(oneHourAfterTime);
 	}
 
-	@Transactional(readOnly = true)
 	public MatchingStatusResponse getBuddyMatchingStatus(String memberId) {
 		Optional<Buddy> optionalBuddy = buddyRepository.findLastBuddyByMemberId(memberId);
 
 		if (optionalBuddy.isPresent()) {
 			Buddy buddy = optionalBuddy.get();
+			checkAndUpdateRejectedBuddyStatus(buddy);
 			return MatchingStatusResponse.buddyFrom(buddy);
 		} else {
 			return null;
+		}
+	}
+
+	private void checkAndUpdateRejectedBuddyStatus(Buddy buddy) {
+		if (buddy.getStatus().equals(BuddyStatus.REJECT) &&
+			isPossibleFromUpdateAt(buddy.getUpdatedAt())) {
+			buddy.changeStatus(BuddyStatus.REACTIVATE);
+			buddyRepository.save(buddy);
 		}
 	}
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #148
## 📌 작업 내용 및 특이사항
- 버디 상태값  REATIVATE 추가
- 버디 상태값 반환 메소드에서 REJECT된 버디의 패널티 처리

## 📝 참고사항
- 

## 📚 기타
- 
