### PR TITLE
♻️ 버디 상태값 요청에 MATCHING_COMPLETED 된 count 같이 넘겨주도록 변경

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyController.java
@@ -47,7 +47,7 @@ public class BuddyController {
 	public MatchingStatusResponse getMatchingStatus() {
 		String memberId =
 			(String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-		return buddyService.getBuddyMatchingStatus(memberId);
+		return buddyService.getBuddyMatchingStatuAndCount(memberId);
 	}
 
 	@Operation(summary = "버디 수락/거절 창에서의 상대방 정보 요청", description = "매칭 후 상대방의 학과, 학년 정보 리턴")

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/MatchingStatusResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/dto/response/MatchingStatusResponse.java
@@ -3,8 +3,8 @@ package com.sejong.sejongpeer.domain.buddy.dto.response;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
 
-public record MatchingStatusResponse(BuddyStatus status) {
-	public static MatchingStatusResponse buddyFrom(Buddy buddy) {
-		return new MatchingStatusResponse(buddy.getStatus());
+public record MatchingStatusResponse(BuddyStatus status, Long matchingCompletedCount) {
+	public static MatchingStatusResponse buddyFrom(Buddy buddy, Long matchingCompletedCount) {
+		return new MatchingStatusResponse(buddy.getStatus(), matchingCompletedCount);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.repository.query.Param;
 
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
-import com.sejong.sejongpeer.domain.member.entity.Member;
 
 public interface BuddyRepository extends JpaRepository<Buddy, Long> {
 	List<Buddy> findAllByStatus(BuddyStatus buddyStatus);
@@ -22,7 +21,6 @@ public interface BuddyRepository extends JpaRepository<Buddy, Long> {
 	Long countByStatusIn(List<BuddyStatus> statuses);
 
 	long countByMemberIdAndStatus(String memberId, BuddyStatus status);
-
 
 	List<Buddy> findAllByMemberIdAndStatus(String memberId, BuddyStatus status);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -103,13 +103,14 @@ public class BuddyService {
 		return LocalDateTime.now().isAfter(oneHourAfterTime);
 	}
 
-	public MatchingStatusResponse getBuddyMatchingStatus(String memberId) {
+	public MatchingStatusResponse getBuddyMatchingStatuAndCount(String memberId) {
 		Optional<Buddy> optionalBuddy = buddyRepository.findLastBuddyByMemberId(memberId);
 
 		if (optionalBuddy.isPresent()) {
 			Buddy buddy = optionalBuddy.get();
 			checkAndUpdateRejectedBuddyStatus(buddy);
-			return MatchingStatusResponse.buddyFrom(buddy);
+			Long matchingCompletedCount = buddyRepository.countByMemberIdAndStatus(memberId, BuddyStatus.MATCHING_COMPLETED);
+			return MatchingStatusResponse.buddyFrom(buddy, matchingCompletedCount);
 		} else {
 			return null;
 		}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #157

## 📌 작업 내용 및 특이사항
- 버디 상태값 요청 응답값에 요청 유저의 Buddy 상태값이 MATCHING_COMPLTED인 count를 포함하여 리턴

## 📝 참고사항
- 

## 📚 기타
- 
