### PR TITLE
✨ 24시간 이내 버디 수락/거절 미응답 시 자동 거절 처리 스케쥴러 구현 및 문자 발송 기능 구현

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyMatchingController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/api/BuddyMatchingController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
@@ -8,7 +8,6 @@ import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface BuddyMatchedRepository extends JpaRepository<BuddyMatched, Long> {

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.repository.query.Param;
 
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
-import com.sejong.sejongpeer.domain.member.entity.Member;
 
 public interface BuddyRepository extends JpaRepository<Buddy, Long> {
 	List<Buddy> findAllByStatus(BuddyStatus buddyStatus);

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
@@ -54,7 +54,7 @@ public class MatchingScheduler {
 				partnerBuddy.changeStatus(BuddyStatus.DENIED);
 				buddyMatchingService.sendMatchingFailurePenaltyMessage(partnerBuddy, SmsText.MATCHING_AUTO_FAILED_DENIED);
 
-				progressMatch.changeStatus(BuddyMatchedStatus.MATCHING_COMPLETED);
+				progressMatch.changeStatus(BuddyMatchedStatus.MATCHING_FAIL);
 
 
 			}

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
@@ -8,8 +8,6 @@ import com.sejong.sejongpeer.domain.buddy.repository.BuddyMatchedRepository;
 import com.sejong.sejongpeer.domain.buddy.repository.BuddyRepository;
 import com.sejong.sejongpeer.domain.buddy.service.BuddyMatchingService;
 import com.sejong.sejongpeer.domain.buddy.service.MatchingService;
-import com.sejong.sejongpeer.global.error.exception.CustomException;
-import com.sejong.sejongpeer.global.error.exception.ErrorCode;
 import com.sejong.sejongpeer.infra.sms.service.SmsService;
 import com.sejong.sejongpeer.infra.sms.service.SmsText;
 import lombok.RequiredArgsConstructor;
@@ -24,10 +22,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MatchingScheduler {
 	private final BuddyRepository buddyRepository;
-	private final BuddyMatchedRepository buddyMatchedRepository;
     private final MatchingService matchingService;
 	private final BuddyMatchingService buddyMatchingService;
-	private final SmsService smsService;
 
     // 매 1시간마다 실행
     @Scheduled(cron = "0 0 0/1 * * *")

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
@@ -4,11 +4,9 @@ import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
 import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;
 import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.type.BuddyMatchedStatus;
-import com.sejong.sejongpeer.domain.buddy.repository.BuddyMatchedRepository;
 import com.sejong.sejongpeer.domain.buddy.repository.BuddyRepository;
 import com.sejong.sejongpeer.domain.buddy.service.BuddyMatchingService;
 import com.sejong.sejongpeer.domain.buddy.service.MatchingService;
-import com.sejong.sejongpeer.infra.sms.service.SmsService;
 import com.sejong.sejongpeer.infra.sms.service.SmsText;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -21,6 +19,8 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class MatchingScheduler {
+	private static final int NO_RESPONSE_HOUR_LIMIT = 24;
+
 	private final BuddyRepository buddyRepository;
     private final MatchingService matchingService;
 	private final BuddyMatchingService buddyMatchingService;
@@ -40,7 +40,7 @@ public class MatchingScheduler {
 			LocalDateTime updatedTime = NoResposeBuddy.getUpdatedAt();
 			long hoursElapsed = ChronoUnit.HOURS.between(updatedTime, currentTime);
 
-			if (hoursElapsed >= 24) {
+			if (hoursElapsed >= NO_RESPONSE_HOUR_LIMIT) {
 				NoResposeBuddy.changeStatus(BuddyStatus.REJECT);
 				buddyMatchingService.sendMatchingFailurePenaltyMessage(NoResposeBuddy, SmsText.MATCHING_AUTO_FAILED_REJECT);
 

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
@@ -41,8 +41,8 @@ public class MatchingScheduler {
 		LocalDateTime currentTime = LocalDateTime.now();
 
 		for (Buddy NoResposeBuddy : foundBuddies) {
-			LocalDateTime createdTime = NoResposeBuddy.getCreatedAt();
-			long hoursElapsed = ChronoUnit.HOURS.between(createdTime, currentTime);
+			LocalDateTime updatedTime = NoResposeBuddy.getUpdatedAt();
+			long hoursElapsed = ChronoUnit.HOURS.between(updatedTime, currentTime);
 
 			if (hoursElapsed >= 24) {
 				NoResposeBuddy.changeStatus(BuddyStatus.REJECT);

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
@@ -36,7 +36,7 @@ public class MatchingScheduler {
     }
 
 	@Scheduled(cron = "0 0 0 */1 * *")
-	public void autoRejectBuddyRequest() {
+	public void updateBuddyStatusAutomatically() {
 		List<Buddy> foundBuddies = buddyRepository.findAllByStatus(BuddyStatus.FOUND_BUDDY);
 		LocalDateTime currentTime = LocalDateTime.now();
 

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
@@ -46,16 +46,16 @@ public class MatchingScheduler {
 
 			if (hoursElapsed >= 24) {
 				NoResposeBuddy.changeStatus(BuddyStatus.REJECT);
-				String autoRejectBuddyPhoneNumber = NoResposeBuddy.getMember().getPhoneNumber();
-				smsService.sendSms(autoRejectBuddyPhoneNumber, SmsText.MATCHING_AUTO_FAILED_REJECT);
+				buddyMatchingService.sendMatchingFailurePenaltyMessage(NoResposeBuddy, SmsText.MATCHING_AUTO_FAILED_REJECT);
 
-				BuddyMatched progressMatch = buddyMatchedRepository.findByOwnerOrPartnerAndStatus(NoResposeBuddy, BuddyMatchedStatus.IN_PROGRESS)
-					.orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND));
+				BuddyMatched progressMatch = buddyMatchingService.getInProgressBuddyMatchedByBuddy(NoResposeBuddy);
 
 				Buddy partnerBuddy = buddyMatchingService.getOtherBuddyInBuddyMatched(progressMatch, NoResposeBuddy);
 				partnerBuddy.changeStatus(BuddyStatus.DENIED);
-				String autoDeniedBuddyPhoneNumber = partnerBuddy.getMember().getPhoneNumber();
-				smsService.sendSms(autoDeniedBuddyPhoneNumber, SmsText.MATCHING_AUTO_FAILED_DENIED);
+				buddyMatchingService.sendMatchingFailurePenaltyMessage(partnerBuddy, SmsText.MATCHING_AUTO_FAILED_DENIED);
+
+				progressMatch.changeStatus(BuddyMatchedStatus.MATCHING_COMPLETED);
+
 
 			}
 		}

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
@@ -1,18 +1,64 @@
 package com.sejong.sejongpeer.domain.buddy.scheduler;
 
+import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
+import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
+import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;
+import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.type.BuddyMatchedStatus;
+import com.sejong.sejongpeer.domain.buddy.repository.BuddyMatchedRepository;
+import com.sejong.sejongpeer.domain.buddy.repository.BuddyRepository;
+import com.sejong.sejongpeer.domain.buddy.service.BuddyMatchingService;
 import com.sejong.sejongpeer.domain.buddy.service.MatchingService;
+import com.sejong.sejongpeer.global.error.exception.CustomException;
+import com.sejong.sejongpeer.global.error.exception.ErrorCode;
+import com.sejong.sejongpeer.infra.sms.service.SmsService;
+import com.sejong.sejongpeer.infra.sms.service.SmsText;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class MatchingScheduler {
+	private final BuddyRepository buddyRepository;
+	private final BuddyMatchedRepository buddyMatchedRepository;
     private final MatchingService matchingService;
+	private final BuddyMatchingService buddyMatchingService;
+	private final SmsService smsService;
 
     // 매 1시간마다 실행
     @Scheduled(cron = "0 0 0/1 * * *")
     public void executeMatchingPeriodically() {
         matchingService.executeMatching();
     }
+
+	@Scheduled(cron = "0 0 0 */1 * *")
+	public void autoRejectBuddyRequest() {
+		List<Buddy> foundBuddies = buddyRepository.findAllByStatus(BuddyStatus.FOUND_BUDDY);
+		LocalDateTime currentTime = LocalDateTime.now();
+
+		for (Buddy NoResposeBuddy : foundBuddies) {
+			LocalDateTime createdTime = NoResposeBuddy.getCreatedAt();
+			long hoursElapsed = ChronoUnit.HOURS.between(createdTime, currentTime);
+
+			if (hoursElapsed >= 24) {
+				NoResposeBuddy.changeStatus(BuddyStatus.REJECT);
+				String autoRejectBuddyPhoneNumber = NoResposeBuddy.getMember().getPhoneNumber();
+				smsService.sendSms(autoRejectBuddyPhoneNumber, SmsText.MATCHING_AUTO_FAILED_REJECT);
+
+				BuddyMatched progressMatch = buddyMatchedRepository.findByOwnerOrPartnerAndStatus(NoResposeBuddy, BuddyMatchedStatus.IN_PROGRESS)
+					.orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND));
+
+				Buddy partnerBuddy = buddyMatchingService.getOtherBuddyInBuddyMatched(progressMatch, NoResposeBuddy);
+				partnerBuddy.changeStatus(BuddyStatus.DENIED);
+				String autoDeniedBuddyPhoneNumber = partnerBuddy.getMember().getPhoneNumber();
+				smsService.sendSms(autoDeniedBuddyPhoneNumber, SmsText.MATCHING_AUTO_FAILED_DENIED);
+
+			}
+		}
+	}
+
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
@@ -7,8 +7,6 @@ import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;
 import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.type.BuddyMatchedStatus;
 import com.sejong.sejongpeer.domain.buddy.repository.BuddyMatchedRepository;
 import com.sejong.sejongpeer.domain.buddy.repository.BuddyRepository;
-import com.sejong.sejongpeer.domain.member.entity.Member;
-import com.sejong.sejongpeer.domain.member.repository.MemberRepository;
 import com.sejong.sejongpeer.global.error.exception.CustomException;
 import com.sejong.sejongpeer.global.error.exception.ErrorCode;
 import com.sejong.sejongpeer.infra.sms.service.SmsService;

--- a/src/main/java/com/sejong/sejongpeer/infra/sms/service/SmsText.java
+++ b/src/main/java/com/sejong/sejongpeer/infra/sms/service/SmsText.java
@@ -8,7 +8,11 @@ public enum SmsText {
 	MATCHING_COMPLETE_BUDDY("[세종피어]버디 매칭에 성공했습니다!\n" +
 		"세종버디에 다시 접속해 버디의 정보를 모두 확인해주세요 :)"),
 	MATCHING_FAILED("[세종피어]매칭에 실패했습니다! 다시 신청해주세요.\n" +
-		"(거절한 버디에겐 1시간 이용제한 페널티가 부여됩니다)");
+		"(거절한 버디에겐 1시간 이용제한 페널티가 부여됩니다)"),
+
+	MATCHING_AUTO_FAILED_DENIED("[세종피어]상대방이 24시간 내에 매칭 확정을 하지 않아 자동 거절처리되었습니다.\n" +
+		"다시 신청해주세요!"),
+	MATCHING_AUTO_FAILED_REJECT("[세종피어]24시간 내에 매칭확정을 하지 않아 거절처리 되었습니다. (1시간 제한 패널티)");
 
 	private final String value;
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #149 

## 📌 작업 내용 및 특이사항
- 기존 버디 수락/거절 메소드를 공동으로 사용하기 위해 BuddyMatchingService 리팩토링
- 스케쥴러 방식으로 구현
- 자동으로 거절된 유저와 거절 당한 유저에게 서로 다른 문자 내용을 발송

## 📝 참고사항
- 

## 📚 기타
- 
