### PR TITLE
♻️ Buddy에서 BuddyMatched 찾는 방식 쿼리문 줄이도록 리팩토링

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
@@ -1,7 +1,6 @@
 package com.sejong.sejongpeer.domain.buddy.repository;
 
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
-import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.type.BuddyMatchedStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyMatchedRepository.java
@@ -14,7 +14,4 @@ public interface BuddyMatchedRepository extends JpaRepository<BuddyMatched, Long
 	@Query("SELECT bm FROM BuddyMatched bm WHERE bm.owner = :owner OR bm.partner = :owner ORDER BY bm.id DESC LIMIT 1")
 	Optional<BuddyMatched> findLatestByOwnerOrPartner(@Param("owner") Buddy owner);
 
-	@Query("SELECT bm FROM BuddyMatched bm WHERE " +
-		"(:owner = bm.owner OR :owner = bm.partner)")
-	Optional<BuddyMatched> findByOwnerOrPartner(@Param("owner") Buddy owner);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyMatchingService.java
@@ -88,8 +88,11 @@ public class BuddyMatchingService {
 	}
 
 	public BuddyMatched getBuddyMatchedByBuddy(Buddy buddy) {
-		return buddyMatchedRepository.findByOwnerOrPartner(buddy)
-			.orElseThrow(() -> new CustomException(ErrorCode.TARGET_BUDDY_NOT_FOUND));
+		if (buddy.getMatchedAsOwner() != null) {
+			return buddy.getMatchedAsOwner();
+		} else {
+			return buddy.getMatchedAsPartner();
+		}
 	}
 
 	public Buddy getOtherBuddyInBuddyMatched(BuddyMatched buddyMatched, Buddy ownerBuddy) {

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/BuddyService.java
@@ -146,8 +146,7 @@ public class BuddyService {
 
 		return completedBuddies.stream()
 			.map(buddy -> {
-				BuddyMatched completedBuddyMatched = buddyMatchedRepository.findByOwnerOrPartner(buddy)
-					.orElseThrow(() -> new CustomException(ErrorCode.BUDDY_NOT_MATCHED));
+				BuddyMatched completedBuddyMatched = buddyMatchingService.getBuddyMatchedByBuddy(buddy);
 
 				Buddy partner = buddyMatchingService.getOtherBuddyInBuddyMatched(completedBuddyMatched, buddy);
 				Member partnerMember = partner.getMember();


### PR DESCRIPTION
## 🌱 관련 이슈
- close #162 

## 📌 작업 내용 및 특이사항
- 버디 수락/거절 로직에서 로그인한 유저의 버디를 이용하여 BuddyMatched를 찾는 방식을 repository를 사용하지 않는 방식으로 변경
- 버디 다 회 신청 가능해지면서 매칭된 모든 상대 유저 정보 반환하는 부분에서도 Buddy로부터 BuddyMatched를 찾을 때 동일한 방식으로 변경

## 📝 참고사항
- 기능적으로 문제 없음을 확인했습니다

## 📚 기타
- 
