### PR TITLE
✨스터디 게시글 무한 스크롤 전체 조회, 단건 상세 조회, 게시글 다중 조건 검색 API

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/externalactivitystudy/repository/ExternalActivityStudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/externalactivitystudy/repository/ExternalActivityStudyRepository.java
@@ -1,11 +1,12 @@
 package com.sejong.sejongpeer.domain.externalactivitystudy.repository;
 
 import com.sejong.sejongpeer.domain.externalactivitystudy.entity.ExternalActivityStudy;
+import com.sejong.sejongpeer.domain.study.entity.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface ExternalActivityStudyRepository extends JpaRepository<ExternalActivityStudy, Long> {
 
-	Optional<ExternalActivityStudy> findByStudyId(Long studyId);
+	Optional<ExternalActivityStudy> findByStudy(Study study);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/externalactivitystudy/repository/ExternalActivityStudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/externalactivitystudy/repository/ExternalActivityStudyRepository.java
@@ -1,0 +1,11 @@
+package com.sejong.sejongpeer.domain.externalactivitystudy.repository;
+
+import com.sejong.sejongpeer.domain.externalactivitystudy.entity.ExternalActivityStudy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ExternalActivityStudyRepository extends JpaRepository<ExternalActivityStudy, Long> {
+
+	Optional<ExternalActivityStudy> findByStudyId(Long studyId);
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/lecturestudy/entity/Lecture.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/lecturestudy/entity/Lecture.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Lecture extends BaseEntity {
+public class Lecture {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -34,6 +34,6 @@ public class Lecture extends BaseEntity {
 
 	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<LectureStudy> lectureStudies = new ArrayList<>();
-  
+
 	private String college; // 단과대
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/lecturestudy/repository/LectureStudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/lecturestudy/repository/LectureStudyRepository.java
@@ -1,0 +1,11 @@
+package com.sejong.sejongpeer.domain.lecturestudy.repository;
+
+import com.sejong.sejongpeer.domain.lecturestudy.entity.LectureStudy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LectureStudyRepository extends JpaRepository<LectureStudy, Long> {
+
+	Optional<LectureStudy> findByStudyId(Long studyId);
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/lecturestudy/repository/LectureStudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/lecturestudy/repository/LectureStudyRepository.java
@@ -1,11 +1,12 @@
 package com.sejong.sejongpeer.domain.lecturestudy.repository;
 
 import com.sejong.sejongpeer.domain.lecturestudy.entity.LectureStudy;
+import com.sejong.sejongpeer.domain.study.entity.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface LectureStudyRepository extends JpaRepository<LectureStudy, Long> {
 
-	Optional<LectureStudy> findByStudyId(Long studyId);
+	Optional<LectureStudy> findByStudy(Study study);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -2,10 +2,7 @@ package com.sejong.sejongpeer.domain.study.api;
 
 import com.sejong.sejongpeer.domain.study.dto.request.StudyCreateRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
-import com.sejong.sejongpeer.domain.study.dto.response.StudyCreateResponse;
-import com.sejong.sejongpeer.domain.study.dto.response.StudyFindResponse;
-import com.sejong.sejongpeer.domain.study.dto.response.StudyTotalPostResponse;
-import com.sejong.sejongpeer.domain.study.dto.response.StudyUpdateResponse;
+import com.sejong.sejongpeer.domain.study.dto.response.*;
 import com.sejong.sejongpeer.domain.study.service.StudyService;
 import com.sejong.sejongpeer.security.util.SecurityContextUtil;
 
@@ -78,4 +75,12 @@ public class StudyController {
 		@RequestParam(defaultValue = "0") int page) {
 		return studyService.getAllStudyPost(choice, page);
 	}
+
+	@Operation(summary = "게시글 단건 상세 조회", description = "게시글 목록 조회에서 리턴 받은 각 게시글 id에 해당하는 게시글의 세부 정보를 반환합니다.")
+	@GetMapping("/post/{studyId}")
+	public StudyPostInfoResponse getOneStudyPostInfo(@PathVariable Long studyId) {
+		return studyService.getOneStudyPostInfo(studyId);
+	}
+
+
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -75,8 +75,7 @@ public class StudyController {
 	@GetMapping("/post/all")
 	public Slice<StudyTotalPostResponse> getAllStudyPost(
 		@RequestParam(name = "choice") String choice,
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "50") int size) {
-		return studyService.getAllStudyPost(choice, page, size);
+		@RequestParam(defaultValue = "0") int page) {
+		return studyService.getAllStudyPost(choice, page);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -4,6 +4,7 @@ import com.sejong.sejongpeer.domain.study.dto.request.StudyCreateRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
 import com.sejong.sejongpeer.domain.study.dto.response.StudyCreateResponse;
 import com.sejong.sejongpeer.domain.study.dto.response.StudyFindResponse;
+import com.sejong.sejongpeer.domain.study.dto.response.StudyTotalPostResponse;
 import com.sejong.sejongpeer.domain.study.dto.response.StudyUpdateResponse;
 import com.sejong.sejongpeer.domain.study.service.StudyService;
 import com.sejong.sejongpeer.security.util.SecurityContextUtil;
@@ -25,6 +26,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "3. [스터디]", description = "스터디 관련 API입니다.")
 @RestController
@@ -67,5 +70,12 @@ public class StudyController {
 	@DeleteMapping("/{studyId}")
 	public void studyDelete(@PathVariable Long studyId) {
 		studyService.deleteStudy(studyId);
+	}
+
+	@Operation(summary = "게시글 목록 조회", description = "학교 수업 스터디 혹은 수업 외 활동 게시글 전체 목록을 반환합니다.")
+	@GetMapping("/post/all")
+	public List<StudyTotalPostResponse> getAllLectureStudyPost(
+		@RequestParam(name = "choice") String choice) {
+		return studyService.getAllLectureStudyPost(choice);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -1,6 +1,7 @@
 package com.sejong.sejongpeer.domain.study.api;
 
 import com.sejong.sejongpeer.domain.study.dto.request.StudyCreateRequest;
+import com.sejong.sejongpeer.domain.study.dto.request.StudySearchRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
 import com.sejong.sejongpeer.domain.study.dto.response.*;
 import com.sejong.sejongpeer.domain.study.service.StudyService;
@@ -22,6 +23,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 
 @Tag(name = "3. [스터디]", description = "스터디 관련 API입니다.")
@@ -78,6 +81,12 @@ public class StudyController {
 	@GetMapping("/post/{studyId}")
 	public StudyPostInfoResponse getOneStudyPostInfo(@PathVariable Long studyId) {
 		return studyService.getOneStudyPostInfo(studyId);
+	}
+
+	@Operation(summary = "게시글 검색", description = "검색 조건에 해당하는 모든 게시글을 반환합니다.")
+	@GetMapping("/post/search")
+	public List<StudyPostInfoResponse> getAllStudyPostBySearch(@RequestBody StudySearchRequest studySearchRequest) {
+		return studyService.getAllStudyPostBySearch(studySearchRequest);
 	}
 
 

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -86,7 +86,7 @@ public class StudyController {
 
 	@Operation(summary = "게시글 검색", description = "검색 조건에 해당하는 모든 게시글을 반환합니다.")
 	@GetMapping("/post/search")
-	public List<StudyTotalPostResponse> getAllStudyPostBySearch(
+	public List<StudyTotalPostResponse> searchPosts(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "20") int size,
 		@Valid @RequestBody StudyPostSearchRequest studyPostSearchRequest) {

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -74,8 +74,10 @@ public class StudyController {
 
 	@Operation(summary = "게시글 목록 조회", description = "학교 수업 스터디 혹은 수업 외 활동 게시글 전체 목록을 반환합니다.")
 	@GetMapping("/post/all")
-	public List<StudyTotalPostResponse> getAllStudyPost(
-		@RequestParam(name = "choice") String choice) {
-		return studyService.getAllStudyPost(choice);
+	public Slice<StudyTotalPostResponse> getAllStudyPost(
+		@RequestParam(name = "choice") String choice,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
+		return studyService.getAllStudyPost(choice, page, size);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -74,8 +74,8 @@ public class StudyController {
 
 	@Operation(summary = "게시글 목록 조회", description = "학교 수업 스터디 혹은 수업 외 활동 게시글 전체 목록을 반환합니다.")
 	@GetMapping("/post/all")
-	public List<StudyTotalPostResponse> getAllLectureStudyPost(
+	public List<StudyTotalPostResponse> getAllStudyPost(
 		@RequestParam(name = "choice") String choice) {
-		return studyService.getAllLectureStudyPost(choice);
+		return studyService.getAllStudyPost(choice);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -85,8 +86,11 @@ public class StudyController {
 
 	@Operation(summary = "게시글 검색", description = "검색 조건에 해당하는 모든 게시글을 반환합니다.")
 	@GetMapping("/post/search")
-	public List<StudyPostInfoResponse> getAllStudyPostBySearch(@RequestBody StudySearchRequest studySearchRequest) {
-		return studyService.getAllStudyPostBySearch(studySearchRequest);
+	public List<StudyTotalPostResponse> getAllStudyPostBySearch(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size,
+		@RequestBody StudySearchRequest studySearchRequest) {
+		return studyService.getAllStudyPostBySearch(page, size, studySearchRequest);
 	}
 
 

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -4,6 +4,7 @@ import com.sejong.sejongpeer.domain.study.dto.request.StudyCreateRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyPostSearchRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
 import com.sejong.sejongpeer.domain.study.dto.response.*;
+import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
 import com.sejong.sejongpeer.domain.study.service.StudyService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,9 +73,9 @@ public class StudyController {
 	@Operation(summary = "게시글 목록 조회", description = "학교 수업 스터디 혹은 수업 외 활동 게시글 전체 목록을 반환합니다.")
 	@GetMapping("/post")
 	public Slice<StudyTotalPostResponse> getAllStudyPost(
-		@RequestParam(name = "choice") String choice,
+		@RequestParam(name = "studyType") StudyType studyType,
 		@RequestParam(defaultValue = "0") int page) {
-		return studyService.getAllStudyPost(choice, page);
+		return studyService.getAllStudyPost(studyType, page);
 	}
 
 	@Operation(summary = "게시글 단건 상세 조회", description = "게시글 목록 조회에서 리턴 받은 각 게시글 id에 해당하는 게시글의 세부 정보를 반환합니다.")

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -1,7 +1,7 @@
 package com.sejong.sejongpeer.domain.study.api;
 
 import com.sejong.sejongpeer.domain.study.dto.request.StudyCreateRequest;
-import com.sejong.sejongpeer.domain.study.dto.request.StudySearchRequest;
+import com.sejong.sejongpeer.domain.study.dto.request.StudyPostSearchRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
 import com.sejong.sejongpeer.domain.study.dto.response.*;
 import com.sejong.sejongpeer.domain.study.service.StudyService;
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -71,7 +70,7 @@ public class StudyController {
 	}
 
 	@Operation(summary = "게시글 목록 조회", description = "학교 수업 스터디 혹은 수업 외 활동 게시글 전체 목록을 반환합니다.")
-	@GetMapping("/post/all")
+	@GetMapping("/post")
 	public Slice<StudyTotalPostResponse> getAllStudyPost(
 		@RequestParam(name = "choice") String choice,
 		@RequestParam(defaultValue = "0") int page) {
@@ -89,8 +88,8 @@ public class StudyController {
 	public List<StudyTotalPostResponse> getAllStudyPostBySearch(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "20") int size,
-		@Valid @RequestBody StudySearchRequest studySearchRequest) {
-		return studyService.getAllStudyPostBySearch(page, size, studySearchRequest);
+		@Valid @RequestBody StudyPostSearchRequest studyPostSearchRequest) {
+		return studyService.getAllStudyPostBySearch(page, size, studyPostSearchRequest);
 	}
 
 

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -76,7 +76,7 @@ public class StudyController {
 	public Slice<StudyTotalPostResponse> getAllStudyPost(
 		@RequestParam(name = "choice") String choice,
 		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "10") int size) {
+		@RequestParam(defaultValue = "50") int size) {
 		return studyService.getAllStudyPost(choice, page, size);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 
 @Tag(name = "3. [스터디]", description = "스터디 관련 API입니다.")
 @RestController

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -28,7 +28,6 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 
-
 @Tag(name = "7-1. [스터디]", description = "스터디 관련 API입니다.")
 @RestController
 @RequestMapping("/api/v1/study")
@@ -90,7 +89,7 @@ public class StudyController {
 	public List<StudyTotalPostResponse> getAllStudyPostBySearch(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "20") int size,
-		@RequestBody StudySearchRequest studySearchRequest) {
+		@Valid @RequestBody StudySearchRequest studySearchRequest) {
 		return studyService.getAllStudyPostBySearch(page, size, studySearchRequest);
 	}
 

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudyPostSearchRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudyPostSearchRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.*;
 
 import java.time.LocalDateTime;
 
-public record StudySearchRequest(
+public record StudyPostSearchRequest(
 
 	@NotNull(message = "검색 시 모집 인원 하한선은 비워둘 수 없습니다.")
 	@Min(value = 2, message = "모집 최소 인원은 2명 이상이어야 합니다.")

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudySearchRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudySearchRequest.java
@@ -2,18 +2,18 @@ package com.sejong.sejongpeer.domain.study.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 import java.time.LocalDateTime;
 
 public record StudySearchRequest(
 
-	@NotBlank(message = "검색 시 모집 인원 하한선은 비워둘 수 없습니다.")
+	@NotNull(message = "검색 시 모집 인원 하한선은 비워둘 수 없습니다.")
+	@Min(value = 2, message = "모집 최소 인원은 2명 이상이어야 합니다.")
 	@Schema(description = "모집 최소 인원") Integer recruitmentMin,
 
-	@NotBlank(message = "검색 시 모집 인원 상한선은 비워둘 수 없습니다.")
+	@NotNull(message = "검색 시 모집 인원 상한선은 비워둘 수 없습니다.")
+	@Max(value = 9, message = "모집 최대 인원은 9명 이하이어야 합니다.")
 	@Schema(description = "모집 최대 인원") Integer recruitmentMax,
 
 	@NotNull(message = "모집 시작 날짜는 비워둘 수 없습니다.")
@@ -35,9 +35,8 @@ public record StudySearchRequest(
 		defaultValue = "2023-05-19 00:00:00",
 		type = "string") LocalDateTime recruitmentEndAt,
 
-	@NotBlank(message = "스터디 모집 여부는 비워둘 수 없습니다.")
-	@Size(max = 5, message = "모집 중은 true, 모집 마감은 false로 요청주세요.")
-	@Schema(description = "스터디 모집 여부")
+	@NotNull(message = "스터디 모집 여부는 비워둘 수 없습니다.")
+	@Schema(description = "스터디 모집 여부에 대해서 모집 중은 true, 모집 마감은 false로 요청주세요.")
 	Boolean isRecruiting,
 
 	@NotBlank(message = "검색어는 비워둘 수 없습니다.")

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudySearchRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudySearchRequest.java
@@ -1,0 +1,45 @@
+package com.sejong.sejongpeer.domain.study.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record StudySearchRequest(
+
+	@NotBlank(message = "검색 시 모집 인원 하한선은 비워둘 수 없습니다.")
+	@Schema(description = "모집 최소 인원") Integer recruitmentMin,
+
+	@NotBlank(message = "검색 시 모집 인원 상한선은 비워둘 수 없습니다.")
+	@Schema(description = "모집 최대 인원") Integer recruitmentMax,
+
+	@NotNull(message = "모집 시작 날짜는 비워둘 수 없습니다.")
+	@JsonFormat(
+		shape = JsonFormat.Shape.STRING,
+		pattern = "yyyy-MM-dd HH:mm:ss",
+		timezone = "Asia/Seoul")
+	@Schema(
+		description = "모집 시작 시간",
+		defaultValue = "2024-05-18 00:00:00",
+		type = "string") LocalDateTime recruitmentStartAt,
+	@NotNull(message = "모집 마감 날짜는 비워둘 수 없습니다.")
+	@JsonFormat(
+		shape = JsonFormat.Shape.STRING,
+		pattern = "yyyy-MM-dd HH:mm:ss",
+		timezone = "Asia/Seoul")
+	@Schema(
+		description = "모집 마감 시간",
+		defaultValue = "2023-05-19 00:00:00",
+		type = "string") LocalDateTime recruitmentEndAt,
+
+	@NotBlank(message = "스터디 모집 여부는 비워둘 수 없습니다.")
+	@Size(max = 5, message = "모집 중은 true, 모집 마감은 false로 요청주세요.")
+	@Schema(description = "스터디 모집 여부")
+	Boolean isRecruiting
+
+) {
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudySearchRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudySearchRequest.java
@@ -39,7 +39,10 @@ public record StudySearchRequest(
 	@NotBlank(message = "스터디 모집 여부는 비워둘 수 없습니다.")
 	@Size(max = 5, message = "모집 중은 true, 모집 마감은 false로 요청주세요.")
 	@Schema(description = "스터디 모집 여부")
-	Boolean isRecruiting
+	Boolean isRecruiting,
+
+	@NotBlank(message = "검색어는 비워둘 수 없습니다.")
+	@Schema(description = "검색어") String searchWord
 
 ) {
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudySearchRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudySearchRequest.java
@@ -1,7 +1,6 @@
 package com.sejong.sejongpeer.domain.study.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
@@ -12,11 +12,11 @@ public record StudyPostInfoResponse(
 	String content,
 	String categoryName
 ) {
-	public static StudyPostInfoResponse fromStudyAndMember(Study study, Member member, String categoryName) {
+	public static StudyPostInfoResponse fromStudy(Study study, String categoryName) {
 		return new StudyPostInfoResponse(
 			study.getTitle(),
-			member.getCollegeMajor().getMajor(),
-			member.getNickname(),
+			study.getMember().getCollegeMajor().getMajor(),
+			study.getMember().getNickname(),
 			study.getRecruitmentStartAt().toString().substring(0, 10),
 			study.getRecruitmentEndAt().toString().substring(0, 10),
 			study.getContent(),

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
@@ -1,5 +1,8 @@
 package com.sejong.sejongpeer.domain.study.dto.response;
 
+import com.sejong.sejongpeer.domain.member.entity.Member;
+import com.sejong.sejongpeer.domain.study.entity.Study;
+
 public record StudyPostInfoResponse(
 	String title,
 	String writerMajor,
@@ -9,4 +12,17 @@ public record StudyPostInfoResponse(
 	String content,
 	String categoryName
 ) {
+	public static StudyPostInfoResponse fromStudyAndMember(Study study, Member member, String categoryName) {
+		return new StudyPostInfoResponse(
+			study.getTitle(),
+			member.getCollegeMajor().getMajor(),
+			member.getNickname(),
+			study.getRecruitmentStartAt().toString().substring(0, 10),
+			study.getRecruitmentEndAt().toString().substring(0, 10),
+			study.getContent(),
+			categoryName
+		);
+	}
+
+	;
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
@@ -1,0 +1,12 @@
+package com.sejong.sejongpeer.domain.study.dto.response;
+
+public record StudyPostInfoResponse(
+	String title,
+	String writerMajor,
+	String writerNickname,
+	String recruitmentStart,
+	String recruitmentEnd,
+	String content,
+	String categoryName
+) {
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
@@ -3,6 +3,7 @@ package com.sejong.sejongpeer.domain.study.dto.response;
 import java.util.List;
 
 public record StudyTotalPostResponse(
+	Long id,
 	String title,
 	String createdAt,
 	Boolean isImage,

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
@@ -1,0 +1,12 @@
+package com.sejong.sejongpeer.domain.study.dto.response;
+
+import java.util.List;
+
+public record StudyTotalPostResponse(
+	String title,
+	String createdAt,
+	Boolean isImage,
+	List<String> postTag
+
+) {
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
@@ -1,7 +1,5 @@
 package com.sejong.sejongpeer.domain.study.dto.response;
 
-import java.util.List;
-
 public record StudyTotalPostResponse(
 	Long id,
 	String title,

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
@@ -1,11 +1,34 @@
 package com.sejong.sejongpeer.domain.study.dto.response;
 
+import com.sejong.sejongpeer.domain.study.entity.Study;
+
 public record StudyTotalPostResponse(
 	Long id,
 	String title,
 	String createdAt,
-	Boolean isImage,
-	String postTag
-
+	boolean hasImage,
+	String categoryName
 ) {
+	public static StudyTotalPostResponse fromLectureStudy(Study study, String lectureName) {
+		boolean hasImage = study.getImageUrl() != null;
+		return new StudyTotalPostResponse(
+			study.getId(),
+			study.getTitle(),
+			study.getCreatedAt().toString().substring(0, 10),
+			hasImage,
+			lectureName
+		);
+	}
+
+	public static StudyTotalPostResponse fromExternalActivityStudy(Study study, String activityCategoryName) {
+		boolean hasImage = study.getImageUrl() != null;
+		return new StudyTotalPostResponse(
+			study.getId(),
+			study.getTitle(),
+			study.getCreatedAt().toString().substring(0, 10),
+			hasImage,
+			activityCategoryName
+		);
+	}
 }
+

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
@@ -7,7 +7,7 @@ public record StudyTotalPostResponse(
 	String title,
 	String createdAt,
 	Boolean isImage,
-	List<String> postTag
+	String postTag
 
 ) {
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
@@ -2,11 +2,16 @@ package com.sejong.sejongpeer.domain.study.repository;
 
 import com.sejong.sejongpeer.domain.study.entity.Study;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom {
 
 	List<Study> findByType(StudyType studyType);
+
+	Slice<Study> findByTypeAndCreatedAtAfter(StudyType studyType, LocalDateTime createdAt, Pageable pageable);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDateTime;
 
 public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom {
-	
+
 	Slice<Study> findByTypeAndCreatedAtBetween(StudyType studyType, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+
+	int countByTypeAndCreatedAtBetween(StudyType studyType, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
@@ -2,16 +2,20 @@ package com.sejong.sejongpeer.domain.study.repository;
 
 import com.sejong.sejongpeer.domain.study.entity.Study;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.time.LocalDateTime;
 
-public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom {
+public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom, JpaSpecificationExecutor<Study> {
 
 	Slice<Study> findByTypeAndCreatedAtBetween(StudyType studyType, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 
 	Long countByTypeAndCreatedAtBetween(StudyType studyType, LocalDateTime startDate, LocalDateTime endDate);
+
+	Page<Study> findAll(Specification<Study> spec, Pageable pageable);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDateTime;
 
 public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom {
-
-
-	Slice<Study> findByTypeAndCreatedAtAfter(StudyType studyType, LocalDateTime createdAt, Pageable pageable);
+	
+	Slice<Study> findByTypeAndCreatedAtBetween(StudyType studyType, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
@@ -7,11 +7,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom {
 
-	List<Study> findByType(StudyType studyType);
 
 	Slice<Study> findByTypeAndCreatedAtAfter(StudyType studyType, LocalDateTime createdAt, Pageable pageable);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
@@ -1,6 +1,12 @@
 package com.sejong.sejongpeer.domain.study.repository;
 
 import com.sejong.sejongpeer.domain.study.entity.Study;
+import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom {}
+import java.util.List;
+
+public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom {
+
+	List<Study> findByType(StudyType studyType);
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/repository/StudyRepository.java
@@ -5,6 +5,7 @@ import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.time.LocalDateTime;
 
@@ -12,5 +13,5 @@ public interface StudyRepository extends JpaRepository<Study, Long>, StudyReposi
 
 	Slice<Study> findByTypeAndCreatedAtBetween(StudyType studyType, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 
-	int countByTypeAndCreatedAtBetween(StudyType studyType, LocalDateTime startDate, LocalDateTime endDate);
+	Long countByTypeAndCreatedAtBetween(StudyType studyType, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -157,6 +157,10 @@ public class StudyService {
 	}
 
 	public List<StudyTotalPostResponse> getAllStudyPostBySearch(Integer page, Integer size, StudySearchRequest request) {
+		if (request.recruitmentMin() > request.recruitmentMax()) {
+			throw new CustomException(ErrorCode.STUDY_SEARCH_PERSONNEL_MISCONDITION);
+		}
+
 		Specification<Study> spec = (root, query, criteriaBuilder) -> null;
 
 		spec = spec.and(StudySpecification.biggerThanRecruitmentMin(request.recruitmentMin()));

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -25,10 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -157,15 +157,12 @@ public class StudyService {
 			throw new CustomException(ErrorCode.STUDY_SEARCH_PERSONNEL_MISCONDITION);
 		}
 
-		Specification<Study> spec = (root, query, criteriaBuilder) -> null;
-
-		spec = spec.and(StudySpecification.biggerThanRecruitmentMin(request.recruitmentMin()));
-		spec = spec.and(StudySpecification.smallerThanRecruitmentMax(request.recruitmentMax()));
-		spec = spec.and(StudySpecification.afterStartedAt(request.recruitmentStartAt()));
-		spec = spec.and(StudySpecification.beforeClosededAt(request.recruitmentEndAt()));
-		spec = spec.and(StudySpecification.equalsRecruitmentStatus(request.isRecruiting()));
-		spec = spec.or(StudySpecification.equalsTitle(request.searchWord()));
-		spec = spec.or(StudySpecification.equalsContent(request.searchWord()));
+		Specification<Study> spec = Specification.where(StudySpecification.biggerThanRecruitmentMin(request.recruitmentMin()))
+			.and(StudySpecification.smallerThanRecruitmentMax(request.recruitmentMax()))
+			.and(StudySpecification.afterStartedAt(request.recruitmentStartAt()))
+			.and(StudySpecification.beforeClosededAt(request.recruitmentEndAt()))
+			.and(StudySpecification.equalsRecruitmentStatus(request.isRecruiting()))
+			.and(StudySpecification.containsTitleOrContent(request.searchWord()));
 
 		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 		Slice<Study> studyPage = studyRepository.findAll(spec, pageable);

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -178,7 +178,7 @@ public class StudyService {
 					throw new CustomException(ErrorCode.STUDY_TYPE_NOT_FOUND);
 				}
 			})
-			.collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+			.collect(Collectors.toUnmodifiableList());
 
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -2,12 +2,9 @@ package com.sejong.sejongpeer.domain.study.service;
 
 import com.sejong.sejongpeer.domain.externalactivitystudy.entity.ExternalActivityStudy;
 import com.sejong.sejongpeer.domain.externalactivitystudy.repository.ExternalActivityStudyRepository;
-import com.sejong.sejongpeer.domain.lecturestudy.entity.Lecture;
 import com.sejong.sejongpeer.domain.lecturestudy.entity.LectureStudy;
-import com.sejong.sejongpeer.domain.lecturestudy.repository.LectureRepository;
 import com.sejong.sejongpeer.domain.lecturestudy.repository.LectureStudyRepository;
 import com.sejong.sejongpeer.domain.member.entity.Member;
-import com.sejong.sejongpeer.domain.member.repository.MemberRepository;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyCreateRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudySearchRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
@@ -27,7 +24,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -40,11 +36,9 @@ public class StudyService {
 	private static final String UNIVERSITY_LECTURE_STUDY = "학교수업스터디";
 	private static final String EXTERNAL_ACTIVITY_STUDY = "수업외활동";
 
-	private final LectureRepository lectureRepository;
 	private final LectureStudyRepository lectureStudyRepository;
 	private final ExternalActivityStudyRepository externalActivityStudyRepository;
 	private final StudyRepository studyRepository;
-	private final MemberRepository memberRepository;
 	private final MemberUtil memberUtil;
 
 	public StudyCreateResponse createStudy(final StudyCreateRequest studyCreateRequest) {

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -1,13 +1,17 @@
 package com.sejong.sejongpeer.domain.study.service;
 
+import com.sejong.sejongpeer.domain.lecturestudy.entity.LectureStudy;
+import com.sejong.sejongpeer.domain.lecturestudy.repository.LectureStudyRepository;
 import com.sejong.sejongpeer.domain.member.entity.Member;
 import com.sejong.sejongpeer.domain.member.repository.MemberRepository;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyCreateRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
 import com.sejong.sejongpeer.domain.study.dto.response.StudyCreateResponse;
 import com.sejong.sejongpeer.domain.study.dto.response.StudyFindResponse;
+import com.sejong.sejongpeer.domain.study.dto.response.StudyTotalPostResponse;
 import com.sejong.sejongpeer.domain.study.dto.response.StudyUpdateResponse;
 import com.sejong.sejongpeer.domain.study.entity.Study;
+import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
 import com.sejong.sejongpeer.domain.study.repository.StudyRepository;
 import com.sejong.sejongpeer.global.error.exception.CustomException;
 import com.sejong.sejongpeer.global.error.exception.ErrorCode;
@@ -18,11 +22,16 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class StudyService {
 
+	private final LectureStudyRepository lectureStudyRepository;
 	private final StudyRepository studyRepository;
 	private final MemberRepository memberRepository;
 
@@ -78,5 +87,41 @@ public class StudyService {
 
 	public void deleteStudy(final Long studyId) {
 		studyRepository.deleteById(studyId);
+	}
+
+	@Transactional(readOnly = true)
+	public List<StudyTotalPostResponse> getAllLectureStudyPost(String choice) {
+
+		List<Study> studyList = new ArrayList<>();
+		;
+		if ("학교수업스터디".equals(choice)) {
+			studyList = studyRepository.findByType(StudyType.LECTURE);
+			for (Study st : studyList) {
+				System.out.println(st.getContent());
+			}
+		}
+
+		List<StudyTotalPostResponse> totalPost = studyList.stream()
+			.map(this::mapToStudyTotalPostResponse)
+			.collect(Collectors.toList());
+		return totalPost;
+	}
+
+	private StudyTotalPostResponse mapToStudyTotalPostResponse(Study study) {
+		boolean hasImage = true;
+		if (study.getImageUrl() == null) hasImage = false;
+
+		LectureStudy lectureStudy = lectureStudyRepository.findByStudyId(study.getId())
+			.orElseThrow(() -> new CustomException(ErrorCode.LECTURE_AND_STUDY_NOT_CONNECTED));
+
+		String lectureName = lectureStudy.getLecture().getName();
+
+		return new StudyTotalPostResponse(
+			study.getId(),
+			study.getTitle(),
+			study.getCreatedAt().toString().substring(0, 10),
+			hasImage,
+			lectureName
+		);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -181,7 +181,7 @@ public class StudyService {
 					throw new CustomException(ErrorCode.STUDY_TYPE_NOT_FOUND);
 				}
 			})
-			.collect(Collectors.toList());
+			.collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
 
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -34,6 +34,9 @@ import java.util.stream.Collectors;
 @Transactional
 public class StudyService {
 
+	private static final String UNIVERSITY_LECTURE_STUDY = "학교수업스터디";
+	private static final String EXTERNAL_ACTIVITY_STUDY = "수업외활동";
+
 	private final LectureStudyRepository lectureStudyRepository;
 	private final ExternalActivityStudyRepository externalActivityStudyRepository;
 	private final StudyRepository studyRepository;
@@ -98,12 +101,12 @@ public class StudyService {
 
 		List<Study> studyList = new ArrayList<>();
 
-		if ("학교수업스터디".equals(choice)) {
+		if (UNIVERSITY_LECTURE_STUDY.equals(choice)) {
 			studyList = studyRepository.findByType(StudyType.LECTURE);
 			return mapToStudyTotalPostResponse(studyList, StudyType.LECTURE);
 		}
 
-		if ("수업외활동".equals(choice)) {
+		if (EXTERNAL_ACTIVITY_STUDY.equals(choice)) {
 			studyList = studyRepository.findByType(StudyType.EXTERNAL_ACTIVITY);
 			return mapToStudyTotalPostResponse(studyList, StudyType.EXTERNAL_ACTIVITY);
 		}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -95,25 +95,29 @@ public class StudyService {
 	}
 
 	@Transactional(readOnly = true)
-	public Slice<StudyTotalPostResponse> getAllStudyPost(String choice, int page, int size) {
+	public Slice<StudyTotalPostResponse> getAllStudyPost(String choice, int page) {
 		LocalDateTime now = LocalDateTime.now();
 		LocalDateTime endDate = now.minusMonths(page * 6);
 		LocalDateTime startDate = endDate.minusMonths(6);
 
-		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+		Pageable pageable;
 		Slice<Study> studySlice;
 
 		if (UNIVERSITY_LECTURE_STUDY.equals(choice)) {
+			int size = studyRepository.countByTypeAndCreatedAtBetween(StudyType.LECTURE, startDate, endDate);
+			pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 			studySlice = studyRepository.findByTypeAndCreatedAtBetween(StudyType.LECTURE, startDate, endDate, pageable);
 			return mapToStudyTotalPostResponse(studySlice, StudyType.LECTURE);
 		}
 
 		if (EXTERNAL_ACTIVITY_STUDY.equals(choice)) {
+			int size = studyRepository.countByTypeAndCreatedAtBetween(StudyType.EXTERNAL_ACTIVITY, startDate, endDate);
+			pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 			studySlice = studyRepository.findByTypeAndCreatedAtBetween(StudyType.EXTERNAL_ACTIVITY, startDate, endDate, pageable);
 			return mapToStudyTotalPostResponse(studySlice, StudyType.EXTERNAL_ACTIVITY);
 		}
 
-		return new SliceImpl<>(Collections.emptyList(), pageable, false);
+		return new SliceImpl<>(Collections.emptyList(), Pageable.unpaged(), false);
 	}
 
 	private Slice<StudyTotalPostResponse> mapToStudyTotalPostResponse(Slice<Study> studySlice, StudyType studyType) {

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -33,9 +33,6 @@ import java.util.stream.Collectors;
 @Transactional
 public class StudyService {
 
-	private static final String UNIVERSITY_LECTURE_STUDY = "학교수업스터디";
-	private static final String EXTERNAL_ACTIVITY_STUDY = "수업외활동";
-
 	private final LectureStudyRepository lectureStudyRepository;
 	private final ExternalActivityStudyRepository externalActivityStudyRepository;
 	private final StudyRepository studyRepository;
@@ -95,7 +92,7 @@ public class StudyService {
 	}
 
 	@Transactional(readOnly = true)
-	public Slice<StudyTotalPostResponse> getAllStudyPost(String choice, int page) {
+	public Slice<StudyTotalPostResponse> getAllStudyPost(StudyType studyType, int page) {
 		LocalDateTime now = LocalDateTime.now();
 		LocalDateTime endDate = now.minusMonths(page * 6);
 		LocalDateTime startDate = endDate.minusMonths(6);
@@ -103,14 +100,14 @@ public class StudyService {
 		Pageable pageable;
 		Slice<Study> studySlice;
 
-		if (UNIVERSITY_LECTURE_STUDY.equals(choice)) {
+		if (StudyType.LECTURE.equals(studyType)) {
 			int size = studyRepository.countByTypeAndCreatedAtBetween(StudyType.LECTURE, startDate, endDate).intValue();
 			pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 			studySlice = studyRepository.findByTypeAndCreatedAtBetween(StudyType.LECTURE, startDate, endDate, pageable);
 			return mapToStudyTotalPostResponse(studySlice, StudyType.LECTURE);
 		}
 
-		if (EXTERNAL_ACTIVITY_STUDY.equals(choice)) {
+		if (StudyType.EXTERNAL_ACTIVITY.equals(studyType)) {
 			int size = studyRepository.countByTypeAndCreatedAtBetween(StudyType.EXTERNAL_ACTIVITY, startDate, endDate).intValue();
 			pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 			studySlice = studyRepository.findByTypeAndCreatedAtBetween(StudyType.EXTERNAL_ACTIVITY, startDate, endDate, pageable);

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -97,7 +97,7 @@ public class StudyService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<StudyTotalPostResponse> getAllLectureStudyPost(String choice) {
+	public List<StudyTotalPostResponse> getAllStudyPost(String choice) {
 
 		List<Study> studyList = new ArrayList<>();
 

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -6,7 +6,7 @@ import com.sejong.sejongpeer.domain.lecturestudy.entity.LectureStudy;
 import com.sejong.sejongpeer.domain.lecturestudy.repository.LectureStudyRepository;
 import com.sejong.sejongpeer.domain.member.entity.Member;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyCreateRequest;
-import com.sejong.sejongpeer.domain.study.dto.request.StudySearchRequest;
+import com.sejong.sejongpeer.domain.study.dto.request.StudyPostSearchRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
 import com.sejong.sejongpeer.domain.study.dto.response.*;
 import com.sejong.sejongpeer.domain.study.entity.Study;
@@ -137,9 +137,8 @@ public class StudyService {
 	public StudyPostInfoResponse getOneStudyPostInfo(Long studyId) {
 		Study study = studyRepository.findById(studyId)
 			.orElseThrow(() -> new CustomException(ErrorCode.STUDY_NOT_FOUND));
-		final Member member = memberUtil.getCurrentMember();
 		String categoryName = getCategoryNameByStudyType(study);
-		return StudyPostInfoResponse.fromStudyAndMember(study, member, categoryName);
+		return StudyPostInfoResponse.fromStudy(study, categoryName);
 	}
 
 	private String getCategoryNameByStudyType(Study study) {
@@ -156,7 +155,7 @@ public class StudyService {
 		}
 	}
 
-	public List<StudyTotalPostResponse> getAllStudyPostBySearch(Integer page, Integer size, StudySearchRequest request) {
+	public List<StudyTotalPostResponse> getAllStudyPostBySearch(Integer page, Integer size, StudyPostSearchRequest request) {
 		if (request.recruitmentMin() > request.recruitmentMax()) {
 			throw new CustomException(ErrorCode.STUDY_SEARCH_PERSONNEL_MISCONDITION);
 		}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -144,11 +144,11 @@ public class StudyService {
 
 	private String getCategoryNameByStudyType(Study study) {
 		if (study.getType() == StudyType.LECTURE) {
-			LectureStudy lectureStudy = lectureStudyRepository.findByStudyId(study.getId())
+			LectureStudy lectureStudy = lectureStudyRepository.findByStudy(study)
 				.orElseThrow(() -> new CustomException(ErrorCode.LECTURE_AND_STUDY_NOT_CONNECTED));
 			return lectureStudy.getLecture().getName();
 		} else if (study.getType() == StudyType.EXTERNAL_ACTIVITY) {
-			ExternalActivityStudy externalActivityStudy = externalActivityStudyRepository.findByStudyId(study.getId())
+			ExternalActivityStudy externalActivityStudy = externalActivityStudyRepository.findByStudy(study)
 				.orElseThrow(() -> new CustomException(ErrorCode.ACTIVITY_AND_STUDY_NOT_CONNECTED));
 			return externalActivityStudy.getExternalActivity().getName();
 		} else {

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -96,17 +96,20 @@ public class StudyService {
 
 	@Transactional(readOnly = true)
 	public Slice<StudyTotalPostResponse> getAllStudyPost(String choice, int page, int size) {
-		LocalDateTime sixMonthsAgo = LocalDateTime.now().minusMonths(6);
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime endDate = now.minusMonths(page * 6);
+		LocalDateTime startDate = endDate.minusMonths(6);
+
 		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 		Slice<Study> studySlice;
 
 		if (UNIVERSITY_LECTURE_STUDY.equals(choice)) {
-			studySlice = studyRepository.findByTypeAndCreatedAtAfter(StudyType.LECTURE, sixMonthsAgo, pageable);
+			studySlice = studyRepository.findByTypeAndCreatedAtBetween(StudyType.LECTURE, startDate, endDate, pageable);
 			return mapToStudyTotalPostResponse(studySlice, StudyType.LECTURE);
 		}
 
 		if (EXTERNAL_ACTIVITY_STUDY.equals(choice)) {
-			studySlice = studyRepository.findByTypeAndCreatedAtAfter(StudyType.EXTERNAL_ACTIVITY, sixMonthsAgo, pageable);
+			studySlice = studyRepository.findByTypeAndCreatedAtBetween(StudyType.EXTERNAL_ACTIVITY, startDate, endDate, pageable);
 			return mapToStudyTotalPostResponse(studySlice, StudyType.EXTERNAL_ACTIVITY);
 		}
 

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -9,6 +9,7 @@ import com.sejong.sejongpeer.domain.lecturestudy.repository.LectureStudyReposito
 import com.sejong.sejongpeer.domain.member.entity.Member;
 import com.sejong.sejongpeer.domain.member.repository.MemberRepository;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyCreateRequest;
+import com.sejong.sejongpeer.domain.study.dto.request.StudySearchRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
 import com.sejong.sejongpeer.domain.study.dto.response.*;
 import com.sejong.sejongpeer.domain.study.entity.Study;
@@ -25,7 +26,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -105,14 +108,14 @@ public class StudyService {
 		Slice<Study> studySlice;
 
 		if (UNIVERSITY_LECTURE_STUDY.equals(choice)) {
-			int size = studyRepository.countByTypeAndCreatedAtBetween(StudyType.LECTURE, startDate, endDate);
+			int size = studyRepository.countByTypeAndCreatedAtBetween(StudyType.LECTURE, startDate, endDate).intValue();
 			pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 			studySlice = studyRepository.findByTypeAndCreatedAtBetween(StudyType.LECTURE, startDate, endDate, pageable);
 			return mapToStudyTotalPostResponse(studySlice, StudyType.LECTURE);
 		}
 
 		if (EXTERNAL_ACTIVITY_STUDY.equals(choice)) {
-			int size = studyRepository.countByTypeAndCreatedAtBetween(StudyType.EXTERNAL_ACTIVITY, startDate, endDate);
+			int size = studyRepository.countByTypeAndCreatedAtBetween(StudyType.EXTERNAL_ACTIVITY, startDate, endDate).intValue();
 			pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 			studySlice = studyRepository.findByTypeAndCreatedAtBetween(StudyType.EXTERNAL_ACTIVITY, startDate, endDate, pageable);
 			return mapToStudyTotalPostResponse(studySlice, StudyType.EXTERNAL_ACTIVITY);
@@ -155,5 +158,9 @@ public class StudyService {
 		} else {
 			throw new CustomException(ErrorCode.STUDY_TYPE_NOT_FOUND);
 		}
+	}
+
+	public List<StudyPostInfoResponse> getAllStudyPostBySearch(StudySearchRequest request) {
+		return new ArrayList<>();
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudySpecification.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudySpecification.java
@@ -1,0 +1,42 @@
+package com.sejong.sejongpeer.domain.study.service;
+
+import com.sejong.sejongpeer.domain.study.entity.Study;
+import com.sejong.sejongpeer.domain.study.entity.type.RecruitmentStatus;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+
+public class StudySpecification {
+
+	public static Specification<Study> biggerThanRecruitmentMin(Integer recruitmentMin) {
+		return (root, query, CriteriaBuilder) -> CriteriaBuilder.greaterThanOrEqualTo(root.get("recruitmentCount"), recruitmentMin);
+	}
+
+	public static Specification<Study> smallerThanRecruitmentMax(Integer recruitmentMax) {
+		return (root, query, CriteriaBuilder) -> CriteriaBuilder.lessThanOrEqualTo(root.get("recruitmentCount"), recruitmentMax);
+	}
+
+	public static Specification<Study> afterStartedAt(LocalDateTime recruitmentStartAt) {
+		return (root, query, CriteriaBuilder) -> CriteriaBuilder.greaterThanOrEqualTo(root.get("recruitmentStartAt"), recruitmentStartAt);
+	}
+
+	public static Specification<Study> beforeClosededAt(LocalDateTime recruitmentEndAt) {
+		return (root, query, CriteriaBuilder) -> CriteriaBuilder.lessThanOrEqualTo(root.get("recruitmentEndAt"), recruitmentEndAt);
+	}
+
+	public static Specification<Study> equalsRecruitmentStatus(Boolean isRecruiting) {
+		if (isRecruiting) {
+			return (root, query, CriteriaBuilder) -> CriteriaBuilder.equal(root.get("recruitmentStatus"), RecruitmentStatus.RECRUITING);
+		} else {
+			return (root, query, CriteriaBuilder) -> CriteriaBuilder.equal(root.get("recruitmentStatus"), RecruitmentStatus.CLOSED);
+		}
+	}
+
+	public static Specification<Study> equalsTitle(String searchWord) {
+		return (root, query, CriteriaBuilder) -> CriteriaBuilder.like(root.get("title"), searchWord);
+	}
+
+	public static Specification<Study> equalsContent(String searchWord) {
+		return (root, query, CriteriaBuilder) -> CriteriaBuilder.like(root.get("content"), searchWord);
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudySpecification.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudySpecification.java
@@ -32,11 +32,10 @@ public class StudySpecification {
 		}
 	}
 
-	public static Specification<Study> equalsTitle(String searchWord) {
-		return (root, query, CriteriaBuilder) -> CriteriaBuilder.like(root.get("title"), searchWord);
-	}
-
-	public static Specification<Study> equalsContent(String searchWord) {
-		return (root, query, CriteriaBuilder) -> CriteriaBuilder.like(root.get("content"), searchWord);
+	public static Specification<Study> containsTitleOrContent(String searchWord) {
+		return (root, query, criteriaBuilder) -> criteriaBuilder.or(
+			criteriaBuilder.like(root.get("title"), "%" + searchWord + "%"),
+			criteriaBuilder.like(root.get("content"), "%" + searchWord + "%")
+		);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
 	LECTURE_AND_STUDY_NOT_CONNECTED(HttpStatus.NOT_FOUND, "스터디 게시글에 대응되는 교내 수업이 없습니다."),
 	ACTIVITY_AND_STUDY_NOT_CONNECTED(HttpStatus.NOT_FOUND, "스터디 게시글에 대응되는 외부 활동 카테고리가 없습니다."),
 	STUDY_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 타입입니다."),
+	STUDY_SEARCH_PERSONNEL_MISCONDITION(HttpStatus.CONFLICT, "스터디 게시글 검색 시 모집 인원 하한선이 상한선을 초과할 수 없습니다."),
 
 	// 버디 등록 거절
 	REJECT_PENALTY(HttpStatus.FORBIDDEN, "짝매칭 이후 거절한 유저는 일정시간 동안 버디를 등록할 수 없습니다."),

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -53,6 +53,7 @@ public enum ErrorCode {
 	STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
 	LECTURE_AND_STUDY_NOT_CONNECTED(HttpStatus.NOT_FOUND, "스터디 게시글에 대응되는 교내 수업이 없습니다."),
 	ACTIVITY_AND_STUDY_NOT_CONNECTED(HttpStatus.NOT_FOUND, "스터디 게시글에 대응되는 외부 활동 카테고리가 없습니다."),
+	STUDY_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 타입입니다."),
 
 	// 버디 등록 거절
 	REJECT_PENALTY(HttpStatus.FORBIDDEN, "짝매칭 이후 거절한 유저는 일정시간 동안 버디를 등록할 수 없습니다."),

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
 	// Study
 	STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
 	LECTURE_AND_STUDY_NOT_CONNECTED(HttpStatus.NOT_FOUND, "스터디 게시글에 대응되는 교내 수업이 없습니다."),
+	ACTIVITY_AND_STUDY_NOT_CONNECTED(HttpStatus.NOT_FOUND, "스터디 게시글에 대응되는 외부 활동 카테고리가 없습니다."),
 
 	// 버디 등록 거절
 	REJECT_PENALTY(HttpStatus.FORBIDDEN, "짝매칭 이후 거절한 유저는 일정시간 동안 버디를 등록할 수 없습니다."),

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
 
 	// Study
 	STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
+	LECTURE_AND_STUDY_NOT_CONNECTED(HttpStatus.NOT_FOUND, "스터디 게시글에 대응되는 교내 수업이 없습니다."),
 
 	// 버디 등록 거절
 	REJECT_PENALTY(HttpStatus.FORBIDDEN, "짝매칭 이후 거절한 유저는 일정시간 동안 버디를 등록할 수 없습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #189 

## 📌 작업 내용 및 특이사항
- 6개월 단위의 전체 게시글 무한 스크롤 기능 구현
- 게시글 상세 조회(글쓴이 전공, 닉네임 등 포함)
- 게시글 다중 조건 검색 

## 📝 참고사항
- Lecture 엔티티가 BaseEntity를 상속 받고 있어 "0000-00-00 00:..." 이렇게 초기화가 되어  created_at 칼럼이 추가가 되었는데 이 부분이 jpa mapping 오류(500 error)를 유발하고 실제 필요가 없는 칼럼이므로 삭제

## 📚 기타
- 
