### PR TITLE
✨축제 기간 세종 버디 매칭 로직 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,9 @@ name: SejongPeer - BackEnd - CD
 on:
   push:
     # main branch에 push(merge)될 경우 실행됩니다.
-    branches: [ "main" ]
+    branches:
+      - main
+      - feature/#199
 
 permissions:
   contents: read

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/repository/BuddyRepository.java
@@ -1,5 +1,7 @@
 package com.sejong.sejongpeer.domain.buddy.repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,4 +25,6 @@ public interface BuddyRepository extends JpaRepository<Buddy, Long> {
 	long countByMemberIdAndStatus(String memberId, BuddyStatus status);
 
 	List<Buddy> findAllByMemberIdAndStatus(String memberId, BuddyStatus status);
+
+	List<Buddy> findAllByCreatedAtBetween(LocalDateTime festivalStartDate, LocalDateTime festivalEndDate);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
@@ -16,6 +16,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
@@ -23,6 +24,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MatchingScheduler {
 	private static final int NO_RESPONSE_HOUR_LIMIT = 24;
+	private static final String FESTIVAL_START_DATE = "2024-05-29T00:00:00";
+	private static final String FESTIVAL_END_DATE = "2024-05-31T23:59:59";
+	private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
 	private final BuddyRepository buddyRepository;
 	private final BuddyMatchedRepository buddyMatchedRepository;
@@ -66,4 +70,16 @@ public class MatchingScheduler {
 		buddyRepository.saveAll(foundBuddies);
 	}
 
+	@Scheduled(cron = "0 0 0 * * *")
+	public void resetBuddyStatusDaily() {
+		LocalDateTime startDate = LocalDateTime.parse(FESTIVAL_START_DATE, DATE_TIME_FORMATTER);
+		LocalDateTime endDate = LocalDateTime.parse(FESTIVAL_END_DATE, DATE_TIME_FORMATTER);
+		List<Buddy> buddiesInFestivalPeriod = buddyRepository.findAllByCreatedAtBetween(startDate, endDate);
+
+		for (Buddy buddy : buddiesInFestivalPeriod) {
+			buddy.changeStatus(BuddyStatus.REACTIVATE);
+		}
+
+		buddyRepository.saveAll(buddiesInFestivalPeriod);
+	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/scheduler/MatchingScheduler.java
@@ -4,6 +4,7 @@ import com.sejong.sejongpeer.domain.buddy.entity.buddy.Buddy;
 import com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus;
 import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.BuddyMatched;
 import com.sejong.sejongpeer.domain.buddy.entity.buddymatched.type.BuddyMatchedStatus;
+import com.sejong.sejongpeer.domain.buddy.repository.BuddyMatchedRepository;
 import com.sejong.sejongpeer.domain.buddy.repository.BuddyRepository;
 import com.sejong.sejongpeer.domain.buddy.service.BuddyMatchingService;
 import com.sejong.sejongpeer.domain.buddy.service.MatchingService;
@@ -24,6 +25,7 @@ public class MatchingScheduler {
 	private static final int NO_RESPONSE_HOUR_LIMIT = 24;
 
 	private final BuddyRepository buddyRepository;
+	private final BuddyMatchedRepository buddyMatchedRepository;
 	private final MatchingService matchingService;
 	private final BuddyMatchingService buddyMatchingService;
 
@@ -56,8 +58,12 @@ public class MatchingScheduler {
 
 				progressMatch.changeStatus(BuddyMatchedStatus.MATCHING_FAIL);
 
+				buddyMatchedRepository.save(progressMatch);
+
 			}
 		}
+
+		buddyRepository.saveAll(foundBuddies);
 	}
 
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/buddy/service/MatchingService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/buddy/service/MatchingService.java
@@ -2,6 +2,7 @@ package com.sejong.sejongpeer.domain.buddy.service;
 
 import static com.sejong.sejongpeer.domain.buddy.entity.buddy.type.BuddyStatus.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -99,8 +100,11 @@ public class MatchingService {
 	}
 
 	private Buddy findSuitableBuddy(List<Buddy> candidates, Buddy me) {
+		LocalDate myRegisterDate = me.getCreatedAt().toLocalDate();
+
 		return candidates.stream()
 			.filter(candidate -> candidate.getId() != me.getId()) // 본인은 제외 시킴
+			.filter(candidate -> candidate.getCreatedAt().toLocalDate().isEqual(myRegisterDate))
 			.filter(
 				candidate ->
 					candidate.getStatus()

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/api/HonbabController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/api/HonbabController.java
@@ -48,7 +48,7 @@ public class HonbabController {
 		return honbabService.getPartnerInfo();
 	}
 
-	@Operation(summary = "혼밥 상대를 찾고있는 이용자 수 요청", description = "IN_PROGRESS인 상태인 혼밥 이용자")
+	@Operation(summary = "혼밥 탈출 총 이용자 수 요청", description = "전체 혼밥 이용자 수 반환")
 	@GetMapping("/active-count")
 	public ActiveCustomersCountResponse getCurrentlyActiveHonbabCount() {
 		return honbabService.getCurrentlyActiveHonbabCount();

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/entity/honbab/type/GenderOption.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/entity/honbab/type/GenderOption.java
@@ -16,13 +16,14 @@ public enum GenderOption {
 			return myGender == candidateGender;
 		}
 	},
-	NO_MATTER("상관없음") {
-		// me가 상관없을 경우, candidate가 동성만 원하는 경우가 있을 수 있음
+	NO_MATTER("이성") {
+		// me와 candidate의 성별이 달라야함
 		@Override
 		public boolean isMatch(
 			Gender myGender, GenderOption candidateOption, Gender candidateGender) {
-			return candidateOption == NO_MATTER
-				|| (candidateOption == SAME && myGender == candidateGender);
+			return candidateOption == NO_MATTER &&
+				myGender != candidateGender;
+
 		}
 	};
 	private final String value;

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/repository/HonbabRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/repository/HonbabRepository.java
@@ -18,4 +18,6 @@ public interface HonbabRepository extends JpaRepository<Honbab, Long> {
 
 	@Query("SELECT COUNT(b) FROM Honbab b WHERE b.status = 'IN_PROGRESS'")
 	Long countByStatusInProgressHonbab();
+
+	Long countByStatus(HonbabStatus inProgress);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/service/HonbabMatchingService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/service/HonbabMatchingService.java
@@ -53,6 +53,7 @@ public class HonbabMatchingService {
 
 	public HonbabMatched matchHonbabWhenRegister(Honbab me) {
 		List<Honbab> candidates = honbabRepository.findAllByStatus(HonbabStatus.IN_PROGRESS);
+
 		return matchHonbabByCandidates(candidates, me);
 	}
 
@@ -67,6 +68,7 @@ public class HonbabMatchingService {
 		}
 
 		HonbabMatched honbabMatched = HonbabMatched.registerMatchingPair(me, partner);
+		honbabMatchedRepository.save(honbabMatched);
 		completeMatching(partner, me);
 		return honbabMatched;
 	}

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/service/HonbabMatchingService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/service/HonbabMatchingService.java
@@ -25,6 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class HonbabMatchingService {
+	private static final long FIXED_WAIT_TIME_SECONDS = 86400; // 24시간
+
 	private final SmsService smsService;
 
 	private final HonbabRepository honbabRepository;
@@ -93,8 +95,7 @@ public class HonbabMatchingService {
 	}
 
 	private boolean isWaitTimeExceeded(Honbab honbab) {
-		long fixedWaitTimeSeconds = 900; // 15분
-		return Duration.between(honbab.getCreatedAt(), LocalDateTime.now()).getSeconds() > fixedWaitTimeSeconds;
+		return Duration.between(honbab.getCreatedAt(), LocalDateTime.now()).getSeconds() > FIXED_WAIT_TIME_SECONDS;
 	}
 
 	private void handleTimeOut(Honbab honbab) {

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/service/HonbabService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/service/HonbabService.java
@@ -10,16 +10,16 @@ import org.springframework.transaction.annotation.Transactional;
 import com.sejong.sejongpeer.domain.buddy.dto.response.ActiveCustomersCountResponse;
 import com.sejong.sejongpeer.domain.honbab.dto.request.RegisterHonbabRequest;
 import com.sejong.sejongpeer.domain.honbab.dto.response.HonbabMatchingStatusResponse;
+import com.sejong.sejongpeer.domain.honbab.dto.response.MatchingPartnerInfoResponse;
 import com.sejong.sejongpeer.domain.honbab.entity.honbab.Honbab;
 import com.sejong.sejongpeer.domain.honbab.entity.honbab.type.HonbabStatus;
+import com.sejong.sejongpeer.domain.honbab.entity.honbabmatched.HonbabMatched;
+import com.sejong.sejongpeer.domain.honbab.repository.HonbabMatchedRepository;
 import com.sejong.sejongpeer.domain.honbab.repository.HonbabRepository;
 import com.sejong.sejongpeer.domain.member.entity.Member;
 import com.sejong.sejongpeer.domain.member.repository.MemberRepository;
 import com.sejong.sejongpeer.global.error.exception.CustomException;
 import com.sejong.sejongpeer.global.error.exception.ErrorCode;
-import com.sejong.sejongpeer.domain.honbab.dto.response.MatchingPartnerInfoResponse;
-import com.sejong.sejongpeer.domain.honbab.entity.honbabmatched.HonbabMatched;
-import com.sejong.sejongpeer.domain.honbab.repository.HonbabMatchedRepository;
 import com.sejong.sejongpeer.global.util.MemberUtil;
 import com.sejong.sejongpeer.global.util.SecurityUtil;
 
@@ -84,7 +84,7 @@ public class HonbabService {
 	}
 
 	public ActiveCustomersCountResponse getCurrentlyActiveHonbabCount() {
-		Long totalHonbabCount = honbabRepository.count();
+		Long totalHonbabCount = honbabRepository.countByStatus(HonbabStatus.IN_PROGRESS);
 		return ActiveCustomersCountResponse.of(totalHonbabCount);
 	}
 

--- a/src/main/java/com/sejong/sejongpeer/domain/honbab/service/HonbabService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/honbab/service/HonbabService.java
@@ -84,8 +84,8 @@ public class HonbabService {
 	}
 
 	public ActiveCustomersCountResponse getCurrentlyActiveHonbabCount() {
-		Long activeHonbabCount = honbabRepository.countByStatusInProgressHonbab();
-		return ActiveCustomersCountResponse.of(activeHonbabCount);
+		Long totalHonbabCount = honbabRepository.count();
+		return ActiveCustomersCountResponse.of(totalHonbabCount);
 	}
 
 	public void cancelHonbab() {

--- a/src/main/java/com/sejong/sejongpeer/infra/sms/service/SmsText.java
+++ b/src/main/java/com/sejong/sejongpeer/infra/sms/service/SmsText.java
@@ -1,8 +1,8 @@
 package com.sejong.sejongpeer.infra.sms.service;
 
 public enum SmsText {
-	MATCHING_FOUND_HONBAB("[세종피어] 밥짝꿍 매칭에 성공했습니다!\n"
-		+ "혼밥탈출에 다시 접속해 밥짝꿍의 정보를 확인해주세요(15분 내)"),
+	MATCHING_FOUND_HONBAB("[세종피어] 대동지 매칭에 성공했습니다!\n"
+		+ "혼축탈출에 다시 접속해 대동지의 정보를 확인해주세요.(당일 내)"),
 	MATCHING_FOUND_BUDDY("[세종피어] 버디를 찾았습니다! \n"
 		+ "세종버디에 재접속해 버디정보(학과, 학년) 확인 후 수락여부를 결정해주세요."),
 	MATCHING_COMPLETE_BUDDY("[세종피어]버디 매칭에 성공했습니다!\n" +


### PR DESCRIPTION
## 🌱 관련 이슈
- close #199 

## 📌 작업 내용 및 특이사항
- 같은 날 신청한 버디만 매칭되도록 createdAt가 동일한지 확인하는 filter를 추가
- 매일 자정마다 축제 시작일~축제 종료일 기간 동안 버디를 신청한 경우 버디 상태를 재신청이 가능한 상태로 자동 초기화


## 📝 참고사항
- 

## 📚 기타
- (2024.05.28) 축제 기간에만 적용되는 단기성 기능 변경이기 때문에 별도로 배포 완료
