### PR TITLE
✨ 교외 활동 카테고리 유형 정보 조회

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/externalactivity/controller/ExternalActivityController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/externalactivity/controller/ExternalActivityController.java
@@ -1,0 +1,27 @@
+package com.sejong.sejongpeer.domain.externalactivity.controller;
+
+import com.sejong.sejongpeer.domain.externalactivity.dto.ExternalActivityCategoryResponse;
+import com.sejong.sejongpeer.domain.externalactivity.service.ExternalActivityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "7. [교외 활동]", description = "교외 활동 관련 API입니다.")
+@RestController
+@RequestMapping("/api/v1/external-activity")
+@RequiredArgsConstructor
+public class ExternalActivityController {
+
+	private final ExternalActivityService externalActivityService;
+
+	@Operation(summary = "교외 활동 종류 조회", description = "스터디 게시글 작성에 필요한 교외 활동 카테고리 정보를 반환합니다.")
+	@GetMapping()
+	public List<ExternalActivityCategoryResponse> getAllExternalActivityCategories() {
+		return externalActivityService.getAllExternalActivityCategories();
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/externalactivity/dto/ExternalActivityCategoryResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/externalactivity/dto/ExternalActivityCategoryResponse.java
@@ -1,0 +1,18 @@
+package com.sejong.sejongpeer.domain.externalactivity.dto;
+
+import com.sejong.sejongpeer.domain.externalactivity.entity.ExternalActivity;
+
+public record ExternalActivityCategoryResponse(
+	Long id,
+	String categoryName,
+	String categoryDescription
+) {
+
+	public static ExternalActivityCategoryResponse from(ExternalActivity externalActivity) {
+		return new ExternalActivityCategoryResponse(
+			externalActivity.getId(),
+			externalActivity.getName(),
+			externalActivity.getDescription()
+		);
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/externalactivity/service/ExternalActivityService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/externalactivity/service/ExternalActivityService.java
@@ -1,0 +1,28 @@
+package com.sejong.sejongpeer.domain.externalactivity.service;
+
+import com.sejong.sejongpeer.domain.externalactivity.dto.ExternalActivityCategoryResponse;
+import com.sejong.sejongpeer.domain.externalactivity.entity.ExternalActivity;
+import com.sejong.sejongpeer.domain.externalactivity.repository.ExternalActivityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ExternalActivityService {
+
+	private final ExternalActivityRepository externalActivityRepository;
+
+	@Transactional(readOnly = true)
+	public List<ExternalActivityCategoryResponse> getAllExternalActivityCategories() {
+		List<ExternalActivity> externalActivityList = externalActivityRepository.findAll();
+
+		return externalActivityList.stream()
+			.map(ExternalActivityCategoryResponse::from)
+			.collect(Collectors.toUnmodifiableList());
+	}
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #215 

## 📌 작업 내용 및 특이사항
- 교외 활동 스터디 게시글 생성 시 필요한 external_activity_id request를 위한 교외 활동 카테고리 전체 정보 조회 API

## 📝 참고사항
- 포스트맨 200 ok 확인

## 📚 기타
- API 명세서(NEW) 페이지에 request, reponse 작성 완료
