### PR TITLE
게시글 생성 API, Study 엔티티 밑 request 수정

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/externalactivity/entity/ExternalActivity.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/externalactivity/entity/ExternalActivity.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ExternalActivity extends BaseEntity {
+public class ExternalActivity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/ExternalActivityStudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/ExternalActivityStudyController.java
@@ -16,7 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "3-1. [대외활동 스터디]", description = "대외활동 스터디 관련 API입니다.")
+@Tag(name = "3-2. [대외활동 스터디]", description = "대외활동 스터디 관련 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/study/external-activity")

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/ExternalActivityStudyCreateRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/ExternalActivityStudyCreateRequest.java
@@ -20,15 +20,10 @@ public record ExternalActivityStudyCreateRequest(
 	@Schema(description = "스터디 내용") String content,
 	@Schema(description = "모집 인원") Integer recruitmentCount,
 
-	@NotBlank(message = "스터디 종류은 비워둘 수 없습니다.")
-	@Schema(description = "스터디 종류") StudyType type,
-
-	@NotBlank(message = "모집 상태는 비워둘 수 없습니다.")
-	@Schema(description = "모집 상태") RecruitmentStatus status,
-	@NotBlank(message = "스터디 방식은 비워둘 수 없습니다.")
+	@NotNull(message = "스터디 방식은 비워둘 수 없습니다.")
 	@Schema(description = "스터디 방식") StudyMethod method,
 
-	@NotBlank(message = "모집빈도는 비워둘 수 없습니다.")
+	@NotNull(message = "모집빈도는 비워둘 수 없습니다.")
 	@Schema(description = "모집빈도") Integer frequency,
 
 	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/ExternalActivityStudyCreateRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/ExternalActivityStudyCreateRequest.java
@@ -3,6 +3,7 @@ package com.sejong.sejongpeer.domain.study.dto.request;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sejong.sejongpeer.domain.study.entity.type.Frequency;
 import com.sejong.sejongpeer.domain.study.entity.type.RecruitmentStatus;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyMethod;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
@@ -24,7 +25,7 @@ public record ExternalActivityStudyCreateRequest(
 	@Schema(description = "스터디 방식") StudyMethod method,
 
 	@NotNull(message = "모집빈도는 비워둘 수 없습니다.")
-	@Schema(description = "모집빈도") Integer frequency,
+	@Schema(description = "모집빈도") Frequency frequency,
 
 	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")
 	@Schema(description = "카카오톡 채팅 링크") String kakaoLink,

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/ExternalActivityStudyCreateRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/ExternalActivityStudyCreateRequest.java
@@ -3,6 +3,9 @@ package com.sejong.sejongpeer.domain.study.dto.request;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sejong.sejongpeer.domain.study.entity.type.RecruitmentStatus;
+import com.sejong.sejongpeer.domain.study.entity.type.StudyMethod;
+import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -16,6 +19,25 @@ public record ExternalActivityStudyCreateRequest(
 	@NotBlank(message = "스터디 내용은 비워둘 수 없습니다.")
 	@Schema(description = "스터디 내용") String content,
 	@Schema(description = "모집 인원") Integer recruitmentCount,
+
+	@NotBlank(message = "스터디 종류은 비워둘 수 없습니다.")
+	@Schema(description = "스터디 종류") StudyType type,
+
+	@NotBlank(message = "모집 상태는 비워둘 수 없습니다.")
+	@Schema(description = "모집 상태") RecruitmentStatus status,
+	@NotBlank(message = "스터디 방식은 비워둘 수 없습니다.")
+	@Schema(description = "스터디 방식") StudyMethod method,
+
+	@NotBlank(message = "모집빈도는 비워둘 수 없습니다.")
+	@Schema(description = "모집빈도") Integer frequency,
+
+	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")
+	@Schema(description = "카카오톡 채팅 링크") String kakaoLink,
+	@Schema(description = "질문 링크") String questionLink,
+
+	@NotNull(message = "대외활동 ID는 비워둘 수 없습니다.")
+	@Schema(description = "대외활동 ID") Long externalActivityId,
+
 	@NotNull(message = "모집 시작 시간은 비워둘 수 없습니다.")
 	@JsonFormat(
 		shape = JsonFormat.Shape.STRING,
@@ -33,13 +55,7 @@ public record ExternalActivityStudyCreateRequest(
 	@Schema(
 		description = "모집 마감 시간",
 		defaultValue = "2023-01-03 00:00:00",
-		type = "string") LocalDateTime recruitmentEndAt,
-	// 모집상태
-	@NotBlank(message = "모집 상태는 비워둘 수 없습니다.")
-	@NotBlank(message = "스터디 방식은 비워둘 수 없습니다.")
-	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")
-	@Schema(description = "카카오톡 오픈채팅 링크") String kakaoLink,
-	@NotNull(message = "대외활동 ID는 비워둘 수 없습니다.")
-	@Schema(description = "대외활동 ID") Long externalActivityId
+		type = "string") LocalDateTime recruitmentEndAt
+
 ) {
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/LectureStudyCreateRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/LectureStudyCreateRequest.java
@@ -3,6 +3,9 @@ package com.sejong.sejongpeer.domain.study.dto.request;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sejong.sejongpeer.domain.study.entity.type.RecruitmentStatus;
+import com.sejong.sejongpeer.domain.study.entity.type.StudyMethod;
+import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -16,6 +19,25 @@ public record LectureStudyCreateRequest(
 	@NotBlank(message = "스터디 내용은 비워둘 수 없습니다.")
 	@Schema(description = "스터디 내용") String content,
 	@Schema(description = "모집 인원") Integer recruitmentCount,
+
+	@NotBlank(message = "스터디 종류은 비워둘 수 없습니다.")
+	@Schema(description = "스터디 종류") StudyType type,
+
+	@NotBlank(message = "모집 상태는 비워둘 수 없습니다.")
+	@Schema(description = "모집 상태") RecruitmentStatus status,
+	@NotBlank(message = "스터디 방식은 비워둘 수 없습니다.")
+	@Schema(description = "스터디 방식") StudyMethod method,
+
+	@NotBlank(message = "모집빈도는 비워둘 수 없습니다.")
+	@Schema(description = "모집빈도") Integer frequency,
+
+	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")
+	@Schema(description = "카카오톡 채팅 링크") String kakaoLink,
+	@Schema(description = "질문 링크") String questionLink,
+
+	@NotNull(message = "강의 ID는 비워둘 수 없습니다.")
+	@Schema(description = "강의 ID") Long lectureId,
+
 	@NotNull(message = "모집 시작 시간은 비워둘 수 없습니다.")
 	@JsonFormat(
 		shape = JsonFormat.Shape.STRING,
@@ -33,13 +55,7 @@ public record LectureStudyCreateRequest(
 	@Schema(
 		description = "모집 마감 시간",
 		defaultValue = "2023-01-03 00:00:00",
-		type = "string") LocalDateTime recruitmentEndAt,
-	// 모집상태
-	@NotBlank(message = "모집 상태는 비워둘 수 없습니다.")
-	@NotBlank(message = "스터디 방식은 비워둘 수 없습니다.")
-	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")
-	@Schema(description = "카카오톡 오픈채팅 링크") String kakaoLink,
-	@NotNull(message = "강의 ID는 비워둘 수 없습니다.")
-	@Schema(description = "강의 ID") Long lectureId
+		type = "string") LocalDateTime recruitmentEndAt
+
 ) {
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/LectureStudyCreateRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/LectureStudyCreateRequest.java
@@ -20,15 +20,10 @@ public record LectureStudyCreateRequest(
 	@Schema(description = "스터디 내용") String content,
 	@Schema(description = "모집 인원") Integer recruitmentCount,
 
-	@NotBlank(message = "스터디 종류은 비워둘 수 없습니다.")
-	@Schema(description = "스터디 종류") StudyType type,
-
-	@NotBlank(message = "모집 상태는 비워둘 수 없습니다.")
-	@Schema(description = "모집 상태") RecruitmentStatus status,
-	@NotBlank(message = "스터디 방식은 비워둘 수 없습니다.")
+	@NotNull(message = "스터디 방식은 비워둘 수 없습니다.")
 	@Schema(description = "스터디 방식") StudyMethod method,
 
-	@NotBlank(message = "모집빈도는 비워둘 수 없습니다.")
+	@NotNull(message = "모집빈도는 비워둘 수 없습니다.")
 	@Schema(description = "모집빈도") Integer frequency,
 
 	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/LectureStudyCreateRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/LectureStudyCreateRequest.java
@@ -3,6 +3,7 @@ package com.sejong.sejongpeer.domain.study.dto.request;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sejong.sejongpeer.domain.study.entity.type.Frequency;
 import com.sejong.sejongpeer.domain.study.entity.type.RecruitmentStatus;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyMethod;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
@@ -24,7 +25,7 @@ public record LectureStudyCreateRequest(
 	@Schema(description = "스터디 방식") StudyMethod method,
 
 	@NotNull(message = "모집빈도는 비워둘 수 없습니다.")
-	@Schema(description = "모집빈도") Integer frequency,
+	@Schema(description = "모집빈도") Frequency frequency,
 
 	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")
 	@Schema(description = "카카오톡 채팅 링크") String kakaoLink,

--- a/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
@@ -67,15 +67,20 @@ public class Study extends BaseAuditEntity {
 	private String imageUrl;
 
 	@Comment("오픈카카오톡 링크")
+	@Column(length = 100, nullable = false)
 	private String kakaoLink;
 
 	@Comment("질문 링크")
+	@Column(length = 100, nullable = false)
 	private String questionLink;
 
 	@Comment("스터디 방식")
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
 	private StudyMethod method;
 
 	@Comment("모임 빈도")
+	@Column(nullable = false)
 	private Integer frequency;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
@@ -56,6 +56,9 @@ public class Study extends BaseAuditEntity {
 	@Comment("모집 인원")
 	private Integer recruitmentCount;
 
+	@Comment("참여 인원")
+	private Integer participantsCount;
+
 	@Comment("스터디 유형")
 	@Enumerated(EnumType.STRING)
 	private StudyType type;
@@ -109,13 +112,11 @@ public class Study extends BaseAuditEntity {
 		String content,
 		Integer recruitmentCount,
 		StudyType type,
-		RecruitmentStatus recruitmentStatus,
 		String imageUrl,
 		String kakaoLink,
 		String questionLink,
 		StudyMethod method,
 		Frequency frequency,
-		ImageUploadStatus uploadStatus,
 		LocalDateTime recruitmentStartAt,
 		LocalDateTime recruitmentEndAt,
 		Member member) {
@@ -123,8 +124,9 @@ public class Study extends BaseAuditEntity {
 		this.content = content;
 		this.recruitmentCount = recruitmentCount;
 		this.type = type;
-		this.uploadStatus = uploadStatus;
-		this.recruitmentStatus = recruitmentStatus;
+		this.participantsCount = 0;
+		this.uploadStatus = ImageUploadStatus.NONE; // 상태값 초기화
+		this.recruitmentStatus = RecruitmentStatus.RECRUITING; // 상태값 초기화
 		this.imageUrl = imageUrl;
 		this.kakaoLink = kakaoLink;
 		this.questionLink = questionLink;
@@ -157,8 +159,6 @@ public class Study extends BaseAuditEntity {
 			.questionLink(questionLink)
 			.method(method)
 			.frequency(frequency)
-			.uploadStatus(ImageUploadStatus.NONE)
-			.recruitmentStatus(RecruitmentStatus.RECRUITING)
 			.recruitmentStartAt(recruitmentStartAt)
 			.recruitmentEndAt(recruitmentEndAt)
 			.member(member)
@@ -170,8 +170,6 @@ public class Study extends BaseAuditEntity {
 			.content(vo.content())
 			.recruitmentCount(vo.recruitmentCount())
 			.type(vo.type())
-			.uploadStatus(ImageUploadStatus.NONE)
-			.recruitmentStatus(RecruitmentStatus.RECRUITING)
 			.recruitmentStartAt(vo.recruitmentStartAt())
 			.recruitmentEndAt(vo.recruitmentEndAt())
 			.kakaoLink(vo.kakaoLink())

--- a/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.sejong.sejongpeer.domain.study.entity.type.Frequency;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyMethod;
 import com.sejong.sejongpeer.domain.studyrelation.entity.StudyRelation;
 import org.hibernate.annotations.Comment;
@@ -81,7 +82,7 @@ public class Study extends BaseAuditEntity {
 
 	@Comment("모임 빈도")
 	@Column(nullable = false)
-	private Integer frequency;
+	private Frequency frequency;
 
 	@Enumerated(EnumType.STRING)
 	private ImageUploadStatus uploadStatus;
@@ -113,7 +114,7 @@ public class Study extends BaseAuditEntity {
 		String kakaoLink,
 		String questionLink,
 		StudyMethod method,
-		Integer frequency,
+		Frequency frequency,
 		ImageUploadStatus uploadStatus,
 		LocalDateTime recruitmentStartAt,
 		LocalDateTime recruitmentEndAt,
@@ -128,7 +129,7 @@ public class Study extends BaseAuditEntity {
 		this.kakaoLink = kakaoLink;
 		this.questionLink = questionLink;
 		this.method = method;
-		this.frequency =frequency;
+		this.frequency = frequency;
 		this.recruitmentStartAt = recruitmentStartAt;
 		this.recruitmentEndAt = recruitmentEndAt;
 
@@ -143,7 +144,7 @@ public class Study extends BaseAuditEntity {
 		String kakaoLink,
 		String questionLink,
 		StudyMethod method,
-		Integer frequency,
+		Frequency frequency,
 		LocalDateTime recruitmentStartAt,
 		LocalDateTime recruitmentEndAt,
 		Member member) {

--- a/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.sejong.sejongpeer.domain.study.entity.type.StudyMethod;
 import com.sejong.sejongpeer.domain.studyrelation.entity.StudyRelation;
 import org.hibernate.annotations.Comment;
 
@@ -68,6 +69,15 @@ public class Study extends BaseAuditEntity {
 	@Comment("오픈카카오톡 링크")
 	private String kakaoLink;
 
+	@Comment("질문 링크")
+	private String questionLink;
+
+	@Comment("스터디 방식")
+	private StudyMethod method;
+
+	@Comment("모임 빈도")
+	private Integer frequency;
+
 	@Enumerated(EnumType.STRING)
 	private ImageUploadStatus uploadStatus;
 
@@ -95,10 +105,13 @@ public class Study extends BaseAuditEntity {
 		StudyType type,
 		RecruitmentStatus recruitmentStatus,
 		String imageUrl,
+		String kakaoLink,
+		String questionLink,
+		StudyMethod method,
+		Integer frequency,
 		ImageUploadStatus uploadStatus,
 		LocalDateTime recruitmentStartAt,
 		LocalDateTime recruitmentEndAt,
-		String kakaoLink,
 		Member member) {
 		this.title = title;
 		this.content = content;
@@ -107,9 +120,13 @@ public class Study extends BaseAuditEntity {
 		this.uploadStatus = uploadStatus;
 		this.recruitmentStatus = recruitmentStatus;
 		this.imageUrl = imageUrl;
+		this.kakaoLink = kakaoLink;
+		this.questionLink = questionLink;
+		this.method = method;
+		this.frequency =frequency;
 		this.recruitmentStartAt = recruitmentStartAt;
 		this.recruitmentEndAt = recruitmentEndAt;
-		this.kakaoLink = kakaoLink;
+
 		this.member = member;
 	}
 
@@ -119,6 +136,9 @@ public class Study extends BaseAuditEntity {
 		Integer recruitmentCount,
 		StudyType type,
 		String kakaoLink,
+		String questionLink,
+		StudyMethod method,
+		Integer frequency,
 		LocalDateTime recruitmentStartAt,
 		LocalDateTime recruitmentEndAt,
 		Member member) {
@@ -128,6 +148,9 @@ public class Study extends BaseAuditEntity {
 			.recruitmentCount(recruitmentCount)
 			.type(type)
 			.kakaoLink(kakaoLink)
+			.questionLink(questionLink)
+			.method(method)
+			.frequency(frequency)
 			.uploadStatus(ImageUploadStatus.NONE)
 			.recruitmentStatus(RecruitmentStatus.RECRUITING)
 			.recruitmentStartAt(recruitmentStartAt)
@@ -146,6 +169,9 @@ public class Study extends BaseAuditEntity {
 			.recruitmentStartAt(vo.recruitmentStartAt())
 			.recruitmentEndAt(vo.recruitmentEndAt())
 			.kakaoLink(vo.kakaoLink())
+			.questionLink(vo.questionLink())
+			.method(vo.method())
+			.frequency(vo.frequency())
 			.member(member)
 			.build();
 	}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/entity/type/Frequency.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/entity/type/Frequency.java
@@ -1,0 +1,15 @@
+package com.sejong.sejongpeer.domain.study.entity.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Frequency {
+
+	WEEKLY_1_2("주 1~2회"),
+	WEEKLY_3_4("주 3~4회"),
+	WEEKLY_5_MORE("주 5회 이상");
+
+	private final String value;
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/entity/type/StudyMethod.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/entity/type/StudyMethod.java
@@ -1,0 +1,16 @@
+package com.sejong.sejongpeer.domain.study.entity.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StudyMethod {
+
+	FACE_TO_FACE("대면"),
+	NON_FACE_TO_FACE("비대면"),
+	BOTH("대면 & 비대면");
+
+
+	private final String value;
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -41,18 +41,6 @@ public class StudyService {
 	private final StudyRelationRepository studyRelationRepository;
 	private final MemberUtil memberUtil;
 
-	private Study createStudyEntity(final Member member, final StudyCreateRequest studyCreateRequest) {
-		return Study.createStudy(
-			studyCreateRequest.title(),
-			studyCreateRequest.content(),
-			studyCreateRequest.recruitmentCount(),
-			studyCreateRequest.type(),
-			studyCreateRequest.kakaoLink(),
-			studyCreateRequest.recruitmentStartAt(),
-			studyCreateRequest.recruitmentEndAt(),
-			member);
-	}
-
 	@Transactional(readOnly = true)
 	public Slice<StudyFindResponse> findSliceStudy(int size, Long lastId) {
 		Slice<Study> studySlice = studyRepository.findStudySlice(size, lastId);

--- a/src/main/java/com/sejong/sejongpeer/domain/study/vo/StudyVo.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/vo/StudyVo.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sejong.sejongpeer.domain.study.dto.request.ExternalActivityStudyCreateRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.LectureStudyCreateRequest;
+import com.sejong.sejongpeer.domain.study.entity.type.Frequency;
 import com.sejong.sejongpeer.domain.study.entity.type.RecruitmentStatus;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyMethod;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
@@ -31,7 +32,7 @@ public record StudyVo(
 	@Schema(description = "스터디 방식") StudyMethod method,
 
 	@NotNull(message = "모집빈도는 비워둘 수 없습니다.")
-	@Schema(description = "모집빈도") Integer frequency,
+	@Schema(description = "모집빈도") Frequency frequency,
 
 	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")
 	@Schema(description = "카카오톡 채팅 링크") String kakaoLink,

--- a/src/main/java/com/sejong/sejongpeer/domain/study/vo/StudyVo.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/vo/StudyVo.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sejong.sejongpeer.domain.study.dto.request.ExternalActivityStudyCreateRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.LectureStudyCreateRequest;
+import com.sejong.sejongpeer.domain.study.entity.type.RecruitmentStatus;
+import com.sejong.sejongpeer.domain.study.entity.type.StudyMethod;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,8 +21,22 @@ public record StudyVo(
 	@NotBlank(message = "스터디 내용은 비워둘 수 없습니다.")
 	@Schema(description = "스터디 내용") String content,
 	@Schema(description = "모집 인원") Integer recruitmentCount,
+
+	@NotBlank(message = "스터디 종류은 비워둘 수 없습니다.")
+	@Schema(description = "스터디 종류") StudyType type,
+
+	@NotBlank(message = "모집 상태는 비워둘 수 없습니다.")
+	@Schema(description = "모집 상태") RecruitmentStatus status,
 	@NotBlank(message = "스터디 방식은 비워둘 수 없습니다.")
-	@Schema(description = "스터디 방식") StudyType type,
+	@Schema(description = "스터디 방식") StudyMethod method,
+
+	@NotBlank(message = "모집빈도는 비워둘 수 없습니다.")
+	@Schema(description = "모집빈도") Integer frequency,
+
+	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")
+	@Schema(description = "카카오톡 채팅 링크") String kakaoLink,
+	@Schema(description = "질문 링크") String questionLink,
+
 	@NotNull(message = "모집 시작 시간은 비워둘 수 없습니다.")
 	@JsonFormat(
 		shape = JsonFormat.Shape.STRING,
@@ -38,12 +54,7 @@ public record StudyVo(
 	@Schema(
 		description = "모집 마감 시간",
 		defaultValue = "2023-01-03 00:00:00",
-		type = "string") LocalDateTime recruitmentEndAt,
-	// 모집상태
-	@NotBlank(message = "모집 상태는 비워둘 수 없습니다.")
-	@NotBlank(message = "스터디 방식은 비워둘 수 없습니다.")
-	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")
-	@Schema(description = "카카오톡 오픈채팅 링크") String kakaoLink
+		type = "string") LocalDateTime recruitmentEndAt
 ) {
 	public static StudyVo from(LectureStudyCreateRequest request) {
 		return new StudyVo(
@@ -51,9 +62,13 @@ public record StudyVo(
 			request.content(),
 			request.recruitmentCount(),
 			StudyType.LECTURE,
+			RecruitmentStatus.RECRUITING,
+			request.method(),
+			request.frequency(),
+			request.kakaoLink(),
+			request.questionLink(),
 			request.recruitmentStartAt(),
-			request.recruitmentEndAt(),
-			request.kakaoLink()
+			request.recruitmentEndAt()
 		);
 	}
 
@@ -63,9 +78,13 @@ public record StudyVo(
 			request.content(),
 			request.recruitmentCount(),
 			StudyType.EXTERNAL_ACTIVITY,
+			RecruitmentStatus.RECRUITING,
+			request.method(),
+			request.frequency(),
+			request.kakaoLink(),
+			request.questionLink(),
 			request.recruitmentStartAt(),
-			request.recruitmentEndAt(),
-			request.kakaoLink()
+			request.recruitmentEndAt()
 		);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/vo/StudyVo.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/vo/StudyVo.java
@@ -26,8 +26,6 @@ public record StudyVo(
 	@NotNull(message = "스터디 종류은 비워둘 수 없습니다.")
 	@Schema(description = "스터디 종류") StudyType type,
 
-	@NotBlank(message = "모집 상태는 비워둘 수 없습니다.")
-	@Schema(description = "모집 상태") RecruitmentStatus status,
 	@NotBlank(message = "스터디 방식은 비워둘 수 없습니다.")
 	@Schema(description = "스터디 방식") StudyMethod method,
 
@@ -63,7 +61,6 @@ public record StudyVo(
 			request.content(),
 			request.recruitmentCount(),
 			StudyType.LECTURE,
-			RecruitmentStatus.RECRUITING,
 			request.method(),
 			request.frequency(),
 			request.kakaoLink(),
@@ -79,7 +76,6 @@ public record StudyVo(
 			request.content(),
 			request.recruitmentCount(),
 			StudyType.EXTERNAL_ACTIVITY,
-			RecruitmentStatus.RECRUITING,
 			request.method(),
 			request.frequency(),
 			request.kakaoLink(),

--- a/src/main/java/com/sejong/sejongpeer/domain/study/vo/StudyVo.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/vo/StudyVo.java
@@ -22,7 +22,7 @@ public record StudyVo(
 	@Schema(description = "스터디 내용") String content,
 	@Schema(description = "모집 인원") Integer recruitmentCount,
 
-	@NotBlank(message = "스터디 종류은 비워둘 수 없습니다.")
+	@NotNull(message = "스터디 종류은 비워둘 수 없습니다.")
 	@Schema(description = "스터디 종류") StudyType type,
 
 	@NotBlank(message = "모집 상태는 비워둘 수 없습니다.")
@@ -30,7 +30,7 @@ public record StudyVo(
 	@NotBlank(message = "스터디 방식은 비워둘 수 없습니다.")
 	@Schema(description = "스터디 방식") StudyMethod method,
 
-	@NotBlank(message = "모집빈도는 비워둘 수 없습니다.")
+	@NotNull(message = "모집빈도는 비워둘 수 없습니다.")
 	@Schema(description = "모집빈도") Integer frequency,
 
 	@NotBlank(message = "카카오톡 오픈채팅 링크는 비워둘 수 없습니다.")

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/api/StudyRelationController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/api/StudyRelationController.java
@@ -59,5 +59,4 @@ public class StudyRelationController {
 	public void earlyCloseRegistration(@PathVariable Long studyId) {
 		studyRelationService.earlyCloseRegistration(studyId);
 	}
-
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 게시글 생성 API
- Request값 불필요한 값 삭제 및 추가
- lecture 엔티티에 BaseEntity로 생성 시간 나타나는 것 삭제
- Study에 현재 참여인원 추가, 모집빈도 Enum 추가, 스터디 방식 추가

## 📝 참고사항
- 

## 📚 기타
- 태그 기능은 아직 구현 못했습니다.
