### PR TITLE
✨ 교내외 스터디 게시글 단건 삭제 

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/LectureStudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/LectureStudyController.java
@@ -52,10 +52,4 @@ public class LectureStudyController {
 		@RequestParam int size, @RequestParam(required = false) Long lastId) {
 		return lectureStudyService.findSliceStudy(size, lastId);
 	}
-
-	@Operation(summary = "교내 스터디 단건 삭제", description = "교내 스터디 게시글 한 개를 삭제합니다.")
-	@DeleteMapping("/{studyId}")
-	public void studyDelete(@PathVariable Long studyId) {
-		lectureStudyService.deleteStudy(studyId);
-	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/StudyController.java
@@ -3,13 +3,7 @@ package com.sejong.sejongpeer.domain.study.api;
 import java.util.List;
 
 import org.springframework.data.domain.Slice;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.sejong.sejongpeer.domain.study.dto.request.StudyPostSearchRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
@@ -35,6 +29,12 @@ public class StudyController {
 	public void updateStudy(
 		@Valid @RequestBody StudyUpdateRequest request, @PathVariable Long studyId) {
 		studyService.updateStudy(request, studyId);
+	}
+
+	@Operation(summary = "스터디 단건 삭제", description = "스터디 게시글 한 개를 삭제합니다.")
+	@DeleteMapping("/{studyId}")
+	public void deleteStudy(@PathVariable Long studyId) {
+		studyService.deleteStudy(studyId);
 	}
 
 	@Operation(summary = "게시글 목록 조회", description = "학교 수업 스터디 혹은 수업 외 활동 게시글 전체 목록을 반환합니다.")

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/LectureStudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/LectureStudyService.java
@@ -74,8 +74,4 @@ public class LectureStudyService {
 		Slice<Study> studySlice = studyRepository.findStudySlice(size, lastId);
 		return studySlice.map(StudyFindResponse::from);
 	}
-
-	public void deleteStudy(final Long studyId) {
-		studyRepository.deleteById(studyId);
-	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -39,6 +39,7 @@ public class StudyService {
 	private final ExternalActivityStudyRepository externalActivityStudyRepository;
 	private final StudyRepository studyRepository;
 	private final StudyRelationRepository studyRelationRepository;
+	private final MemberUtil memberUtil;
 
 
 	public StudyUpdateResponse updateStudy(final StudyUpdateRequest studyUpdateRequest, final Long studyId) {
@@ -58,6 +59,12 @@ public class StudyService {
 	public void deleteStudy(final Long studyId) {
 		Study study = studyRepository.findById(studyId)
 			.orElseThrow(() -> new CustomException(ErrorCode.STUDY_NOT_FOUND));
+
+		Member loginMember = memberUtil.getCurrentMember();
+
+		if (!loginMember.equals(study.getMember())) {
+			throw new CustomException(ErrorCode.STUDY_CANNOT_DELETED);
+		}
 
 		if (StudyType.LECTURE.equals(study.getType())) {
 			LectureStudy targetLectureStudy = lectureStudyRepository.findByStudy(study)

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
 	MAX_BUDDY_REGISTRATION_EXCEEDED(HttpStatus.FORBIDDEN, "최대 등록 횟수를 초과했습니다."),
 
 	// Study
+	STUDY_CANNOT_DELETED(HttpStatus.BAD_REQUEST, "스터디 게시글 작성자만 해당 게시글을 삭제할 수 있습니다."),
 	STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
 	STUDY_RELATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스터디의 신청내역을 찾을 수 없습니다."),
 	STUDY_NOT_OWNER(HttpStatus.FORBIDDEN, "스터디의 소유자가 아닙니다."),

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -57,11 +57,13 @@ public enum ErrorCode {
 
 	// Lecture
 	LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강의를 찾을 수 없습니다."),
+	LECTURE_STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 교내 수업 스터디 게시글을 찾을 수 없습니다."),
+	ACTIVITY_AND_STUDY_NOT_CONNECTED(HttpStatus.NOT_FOUND, "스터디 게시글에 대응되는 외부 활동 카테고리가 없습니다."),
 
 	// ExternalActivity
 	EXTERNAL_ACTIVITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 외부활동을 찾을 수 없습니다."),
 	LECTURE_AND_STUDY_NOT_CONNECTED(HttpStatus.NOT_FOUND, "스터디 게시글에 대응되는 교내 수업이 없습니다."),
-	ACTIVITY_AND_STUDY_NOT_CONNECTED(HttpStatus.NOT_FOUND, "스터디 게시글에 대응되는 외부 활동 카테고리가 없습니다."),
+	EXTERNAL_ACTIVITY_STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 교외 활동 스터디 게시글을 찾을 수 없습니다."),
 	STUDY_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 타입입니다."),
 	STUDY_SEARCH_PERSONNEL_MISCONDITION(HttpStatus.CONFLICT, "스터디 게시글 검색 시 모집 인원 하한선이 상한선을 초과할 수 없습니다."),
 	DUPLICATED_STUDY_APPLICATION(HttpStatus.CONFLICT, "이미 해당 스터디에 지원한 이력이 있습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #217 

## 📌 작업 내용 및 특이사항
- 외래키 제약 조건 고려
- 하나의 컨트롤러로 교내 및 교외 스터디 게시글 관련 튜플 모두 삭제
- 게시글 작성자만 삭제 가능하도록 예외 처리 완료
- 프론트에서 존재하지 않는 스터디 id로 요청 시 예외 처리 완료

## 📝 참고사항
- 

## 📚 기타
- 
