### PR TITLE
✨ 스터디 게시글 이미지 base64 string 처리 및 병렬 S3 업로드, 상세 조회 시 이미지 반환 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 
 	// AWS
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'software.amazon.awssdk:s3:2.23.19'
 
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly "com.mysql:mysql-connector-j:8.2.0"

--- a/src/main/java/com/sejong/sejongpeer/domain/image/api/ImageController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/api/ImageController.java
@@ -18,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 @Tag(name = "6. [이미지]", description = "이미지 API")
 @RestController
@@ -50,8 +52,7 @@ public class ImageController {
 		summary = "스터디 게시글 별 이미지 업로드",
 		description = "스터디 이미지를 클라우드에 업로드하여 이미지 경로를 반환합니다.")
 	@PostMapping("/study/upload")
-	public StudyImageUrlResponse uploadStudyImage(@RequestBody StudyImageUploadRequest request) throws IOException {
-		String url = imageService.uploadFile(request.studyId(), request.base64Image());
-		return new StudyImageUrlResponse(url);
+	public List<StudyImageUrlResponse> uploadStudyImage(@RequestBody StudyImageUploadRequest request) throws ExecutionException, InterruptedException {
+		return imageService.uploadFiles(request.studyId(), request);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/api/ImageController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/api/ImageController.java
@@ -50,9 +50,8 @@ public class ImageController {
 		summary = "스터디 게시글 별 이미지 업로드",
 		description = "스터디 이미지를 클라우드에 업로드하여 이미지 경로를 반환합니다.")
 	@PostMapping("/study/upload")
-	public StudyImageUrlResponse uploadStudyImage(@ModelAttribute StudyImageUploadRequest request) throws IOException {
-		MultipartFile file = request.file();
-		String url = imageService.uploadFile(file);
+	public StudyImageUrlResponse uploadStudyImage(@RequestBody StudyImageUploadRequest request) throws IOException {
+		String url = imageService.uploadFile(request.base64Image(), request.fileName());
 		return new StudyImageUrlResponse(url);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/api/ImageController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/api/ImageController.java
@@ -1,9 +1,10 @@
 package com.sejong.sejongpeer.domain.image.api;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.sejong.sejongpeer.domain.image.dto.request.StudyImageUploadRequest;
+import com.sejong.sejongpeer.domain.image.dto.response.StudyImageUrlResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.*;
 
 import com.sejong.sejongpeer.domain.image.dto.request.StudyImageCreateRequest;
 import com.sejong.sejongpeer.domain.image.dto.request.StudyImageUploadCompleteRequest;
@@ -14,12 +15,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(name = "6. [이미지]", description = "이미지 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/image")
 public class ImageController {
+	private static final Logger logger = LoggerFactory.getLogger(ImageController.class);
 
 	private final ImageService imageService;
 
@@ -39,5 +44,15 @@ public class ImageController {
 	public void uploadedStudyImage(
 		@Valid @RequestBody StudyImageUploadCompleteRequest request) {
 		imageService.uploadCompleteStudyImage(request);
+	}
+
+	@Operation(
+		summary = "스터디 게시글 별 이미지 업로드",
+		description = "스터디 이미지를 클라우드에 업로드하여 이미지 경로를 반환합니다.")
+	@PostMapping("/study/upload")
+	public StudyImageUrlResponse uploadStudyImage(@ModelAttribute StudyImageUploadRequest request) throws IOException {
+		MultipartFile file = request.file();
+		String url = imageService.uploadFile(file);
+		return new StudyImageUrlResponse(url);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/api/ImageController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/api/ImageController.java
@@ -51,7 +51,7 @@ public class ImageController {
 		description = "스터디 이미지를 클라우드에 업로드하여 이미지 경로를 반환합니다.")
 	@PostMapping("/study/upload")
 	public StudyImageUrlResponse uploadStudyImage(@RequestBody StudyImageUploadRequest request) throws IOException {
-		String url = imageService.uploadFile(request.base64Image(), request.fileName());
+		String url = imageService.uploadFile(request.studyId(), request.base64Image());
 		return new StudyImageUrlResponse(url);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/dto/request/StudyImageUploadRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/dto/request/StudyImageUploadRequest.java
@@ -1,0 +1,8 @@
+package com.sejong.sejongpeer.domain.image.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record StudyImageUploadRequest(
+	Long studyId,
+	MultipartFile file
+) { }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/dto/request/StudyImageUploadRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/dto/request/StudyImageUploadRequest.java
@@ -1,8 +1,7 @@
 package com.sejong.sejongpeer.domain.image.dto.request;
 
-import org.springframework.web.multipart.MultipartFile;
 
 public record StudyImageUploadRequest(
-	String base64Image,
-	String fileName
+	Long studyId,
+	String base64Image
 ) { }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/dto/request/StudyImageUploadRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/dto/request/StudyImageUploadRequest.java
@@ -3,6 +3,6 @@ package com.sejong.sejongpeer.domain.image.dto.request;
 import org.springframework.web.multipart.MultipartFile;
 
 public record StudyImageUploadRequest(
-	Long studyId,
-	MultipartFile file
+	String base64Image,
+	String fileName
 ) { }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/dto/request/StudyImageUploadRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/dto/request/StudyImageUploadRequest.java
@@ -1,7 +1,9 @@
 package com.sejong.sejongpeer.domain.image.dto.request;
 
 
+import java.util.List;
+
 public record StudyImageUploadRequest(
 	Long studyId,
-	String base64Image
+	List<String> base64ImagesList
 ) { }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/dto/response/StudyImageUrlResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/dto/response/StudyImageUrlResponse.java
@@ -1,0 +1,5 @@
+package com.sejong.sejongpeer.domain.image.dto.response;
+
+public record StudyImageUrlResponse(
+	String imgUrl
+) { }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/dto/response/StudyImageUrlResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/dto/response/StudyImageUrlResponse.java
@@ -1,5 +1,6 @@
 package com.sejong.sejongpeer.domain.image.dto.response;
 
 public record StudyImageUrlResponse(
+	Long imageId,
 	String imgUrl
 ) { }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/dto/response/StudyImageUrlResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/dto/response/StudyImageUrlResponse.java
@@ -1,6 +1,15 @@
 package com.sejong.sejongpeer.domain.image.dto.response;
 
+import com.sejong.sejongpeer.domain.image.entity.Image;
+
 public record StudyImageUrlResponse(
 	Long imageId,
 	String imgUrl
-) { }
+) {
+	public static StudyImageUrlResponse fromImage(Image image) {
+		return new StudyImageUrlResponse(
+			image.getId(),
+			image.getImgUrl()
+		);
+	}
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/image/entity/Image.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/entity/Image.java
@@ -20,6 +20,8 @@ public class Image extends BaseAuditEntity {
 	@Column(name = "image_id")
 	private Long id;
 
+	private String imgUrl;
+
 	@Enumerated(EnumType.STRING)
 	private ImageType imageType;
 
@@ -39,12 +41,14 @@ public class Image extends BaseAuditEntity {
 	private Image(
 		Long id,
 		Study study,
+		String imgUrl,
 		ImageType imageType,
 		Long targetId,
 		String imageKey,
 		ImageFileExtension imageFileExtension) {
 		this.id = id;
 		this.study = study;
+		this.imgUrl = imgUrl;
 		this.imageType = imageType;
 		this.targetId = targetId;
 		this.imageKey = imageKey;
@@ -63,6 +67,15 @@ public class Image extends BaseAuditEntity {
 			.targetId(targetId)
 			.imageKey(imageKey)
 			.imageFileExtension(imageFileExtension)
+			.build();
+	}
+
+	public static Image createBase64ToImage(
+		Study study,
+		String imgUrl) {
+		return Image.builder()
+			.study(study)
+			.imgUrl(imgUrl)
 			.build();
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/image/entity/Image.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/entity/Image.java
@@ -4,6 +4,7 @@ import com.sejong.sejongpeer.domain.common.BaseAuditEntity;
 import com.sejong.sejongpeer.domain.image.entity.type.ImageFileExtension;
 import com.sejong.sejongpeer.domain.image.entity.type.ImageType;
 
+import com.sejong.sejongpeer.domain.study.entity.Study;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -30,14 +31,20 @@ public class Image extends BaseAuditEntity {
 	@Enumerated(EnumType.STRING)
 	private ImageFileExtension imageFileExtension;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "study_id")
+	private Study study;
+
 	@Builder(access = AccessLevel.PRIVATE)
 	private Image(
 		Long id,
+		Study study,
 		ImageType imageType,
 		Long targetId,
 		String imageKey,
 		ImageFileExtension imageFileExtension) {
 		this.id = id;
+		this.study = study;
 		this.imageType = imageType;
 		this.targetId = targetId;
 		this.imageKey = imageKey;
@@ -45,11 +52,13 @@ public class Image extends BaseAuditEntity {
 	}
 
 	public static Image createImage(
+		Study study,
 		ImageType imageType,
 		Long targetId,
 		String imageKey,
 		ImageFileExtension imageFileExtension) {
 		return Image.builder()
+			.study(study)
 			.imageType(imageType)
 			.targetId(targetId)
 			.imageKey(imageKey)

--- a/src/main/java/com/sejong/sejongpeer/domain/image/service/ImageService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/service/ImageService.java
@@ -1,6 +1,8 @@
 package com.sejong.sejongpeer.domain.image.service;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
 
@@ -188,13 +190,18 @@ public class ImageService {
 		return expiration;
 	}
 
-	public String uploadFile(MultipartFile file) throws IOException {
-		String fileName = file.getOriginalFilename();
-		ObjectMetadata metadata = new ObjectMetadata();
-		metadata.setContentLength(file.getSize());
-		metadata.setContentType(file.getContentType());
+	public String uploadFile(String base64Image, String fileName) throws IOException {
 
-		amazonS3.putObject(s3Properties.bucket(), fileName, file.getInputStream(), metadata);
+		String base64ImageData = base64Image.replaceFirst("^data:image/[^;]+;base64,", "");
+
+		byte[] imageBytes = Base64.getDecoder().decode(base64ImageData);
+		ByteArrayInputStream inputStream = new ByteArrayInputStream(imageBytes);
+
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentLength(imageBytes.length);
+		metadata.setContentType("image/png");
+
+		amazonS3.putObject(s3Properties.bucket(), fileName, inputStream, metadata);
 
 		return amazonS3.getUrl(s3Properties.bucket(), fileName).toExternalForm();
 	}

--- a/src/main/java/com/sejong/sejongpeer/domain/image/service/ImageService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/service/ImageService.java
@@ -72,6 +72,7 @@ public class ImageService {
 
 		imageRepository.save(
 			Image.createImage(
+				study,
 				ImageType.STUDY,
 				request.studyId(),
 				imageKey,

--- a/src/main/java/com/sejong/sejongpeer/domain/image/service/ImageService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/service/ImageService.java
@@ -1,8 +1,10 @@
 package com.sejong.sejongpeer.domain.image.service;
 
+import java.io.IOException;
 import java.util.Date;
 import java.util.UUID;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,8 @@ import com.sejong.sejongpeer.global.util.SpringEnvironmentUtil;
 import com.sejong.sejongpeer.infra.config.properties.S3Properties;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +43,7 @@ public class ImageService {
 	private final SpringEnvironmentUtil springEnvironmentUtil;
 	private final S3Properties s3Properties;
 	private final AmazonS3 amazonS3;
+	private final S3Client s3Client;
 	private final ImageRepository imageRepository;
 	private final StudyRepository studyRepository;
 	private final MemberRepository memberRepository;
@@ -181,6 +186,17 @@ public class ImageService {
 		expTimeMillis += 1000 * 60 * 30;
 		expiration.setTime(expTimeMillis);
 		return expiration;
+	}
+
+	public String uploadFile(MultipartFile file) throws IOException {
+		String fileName = file.getOriginalFilename();
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentLength(file.getSize());
+		metadata.setContentType(file.getContentType());
+
+		amazonS3.putObject(s3Properties.bucket(), fileName, file.getInputStream(), metadata);
+
+		return amazonS3.getUrl(s3Properties.bucket(), fileName).toExternalForm();
 	}
 
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
@@ -1,6 +1,10 @@
 package com.sejong.sejongpeer.domain.study.dto.response;
 
+import com.sejong.sejongpeer.domain.image.dto.response.StudyImageUrlResponse;
 import com.sejong.sejongpeer.domain.study.entity.Study;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public record StudyPostInfoResponse(
 	String title,
@@ -11,7 +15,7 @@ public record StudyPostInfoResponse(
 	String content,
 	String categoryName,
 	Long numberOfApplicants,
-	String imgUrl
+	List<StudyImageUrlResponse> imgUrlList
 ) {
 	public static StudyPostInfoResponse fromStudy(Study study, String categoryName, Long numberOfApplicants) {
 		return new StudyPostInfoResponse(
@@ -23,7 +27,7 @@ public record StudyPostInfoResponse(
 			study.getContent(),
 			categoryName,
 			numberOfApplicants,
-			study.getImageUrl()
+			study.getImages().stream().map(StudyImageUrlResponse::fromImage).collect(Collectors.toUnmodifiableList())
 		);
 	}
 

--- a/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.sejong.sejongpeer.domain.image.entity.Image;
 import com.sejong.sejongpeer.domain.study.entity.type.Frequency;
 import com.sejong.sejongpeer.domain.study.entity.type.StudyMethod;
 import com.sejong.sejongpeer.domain.studyrelation.entity.StudyRelation;
@@ -112,6 +113,9 @@ public class Study extends BaseAuditEntity {
 
 	@OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
 	private Set<StudyTagMap> studyTagMaps = new HashSet<>();
+
+	@OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Image> images = new ArrayList<>();
 
 	@Builder(access = AccessLevel.PRIVATE)
 	private Study(

--- a/src/main/java/com/sejong/sejongpeer/infra/config/aws/S3Config.java
+++ b/src/main/java/com/sejong/sejongpeer/infra/config/aws/S3Config.java
@@ -11,6 +11,9 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.sejong.sejongpeer.infra.config.properties.S3Properties;
 
 import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 @RequiredArgsConstructor
@@ -30,6 +33,14 @@ public class S3Config {
 		return AmazonS3ClientBuilder.standard()
 			.withCredentials(new AWSStaticCredentialsProvider(awsCredentialsProvider()))
 			.withRegion(s3Properties.region())
+			.build();
+	}
+
+	@Bean
+	public S3Client s3Client() {
+		return S3Client.builder()
+			.region(Region.of(s3Properties.region()))
+			.credentialsProvider(ProfileCredentialsProvider.create())
 			.build();
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #230 

## 📌 작업 내용 및 특이사항
- 여러 개의 파일을 한번에 업로드 구현 완료
- 프론트에서 List<String> 형식으로 base64 string 인코딩된 이미지를 request로 받음
- 백에서 이 이미지를 디코딩해서 이미지 파일로 변환하여 S3에 업로드 및 DB에 URL 저장
- 게시글 상세 조회 시 study 테이블의 img_url 칼럼이 아니라 스터디와 이미지 일대다 관계로 새롭게 정의한 이미지 테이블에서 List 형식으로 이미지 아이디와 함께 반환하도록 로직 수정

## 📝 참고사항
- 급하게 구현했기 때문에 추후 코드 리펙토링 예정

## 📚 기타
- 200 ok 이미지 업로드 및 게시글 상세 조회 api 확인 완료
