### PR TITLE
✨ 스터디 지원자에 대한 수락/거절 상태 변경 및 수락일 경우 참여 인원 증가 처리 API

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/member/repository/MemberRepository.java
@@ -22,4 +22,6 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 	Optional<Member> findByAccountAndStudentId(String account, String studentId);
 
 	Optional<Member> findByStudentIdAndName(String studentId, String name);
+
+	Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudyMatchingRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/StudyMatchingRequest.java
@@ -1,0 +1,10 @@
+package com.sejong.sejongpeer.domain.study.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record StudyMatchingRequest(
+	@NotNull(message = "스터디 게시글 id를 입력해주세요.") Long studyId,
+	@NotNull(message = "수락/거절 하려는 지원자의 닉네임을 입력해주세요.") String applicantNickname,
+	@NotNull(message = "스터디 지원자를 수락하려면 true, 거절하려면 false로 요청해주세요.") boolean isAccept
+) {
+}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/entity/Study.java
@@ -225,4 +225,8 @@ public class Study extends BaseAuditEntity {
 		tagMap.setStudy(this);
 	}
 
+	public void addParticipantsCount() {
+		this.participantsCount++;
+	}
+
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/api/StudyRelationController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/api/StudyRelationController.java
@@ -1,6 +1,6 @@
 package com.sejong.sejongpeer.domain.studyrelation.api;
 
-import com.sejong.sejongpeer.domain.study.dto.request.StudyMatchingRequest;
+import com.sejong.sejongpeer.domain.studyrelation.dto.request.StudyMatchingRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/api/StudyRelationController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/api/StudyRelationController.java
@@ -44,7 +44,7 @@ public class StudyRelationController {
 	}
 
 	@Operation(summary = "스터디 지원자 수락/거절", description = "자신이 개설한 스터디 지원자의 스터디 신청에 대해 수락/거절을 처리합니다.")
-	@PutMapping("/matching/status")
+	@PatchMapping("/matching/status")
 	public void processStudyMatchingStatus(@Valid @RequestBody StudyMatchingRequest request) {
 		studyRelationService.updateStudyMatchingStatus(request);
 	}

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/api/StudyRelationController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/api/StudyRelationController.java
@@ -1,5 +1,6 @@
 package com.sejong.sejongpeer.domain.studyrelation.api;
 
+import com.sejong.sejongpeer.domain.study.dto.request.StudyMatchingRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -42,16 +43,10 @@ public class StudyRelationController {
 		return null;
 	}
 
-	@Operation(summary = "스터디 수락", description = "스터디 신청을 수락합니다.")
-	@PutMapping("/accept")
-	public ResponseEntity<?> acceptStudyRelation() {
-		return null;
-	}
-
-	@Operation(summary = "스터디 거부", description = "스터디 신청을 거부합니다.")
-	@PutMapping("/reject")
-	public ResponseEntity<?> rejectStudyRelation() {
-		return null;
+	@Operation(summary = "스터디 지원자 수락/거절", description = "자신이 개설한 스터디 지원자의 스터디 신청에 대해 수락/거절을 처리합니다.")
+	@PutMapping("/matching/status")
+	public void processStudyMatchingStatus(@Valid @RequestBody StudyMatchingRequest request) {
+		studyRelationService.updateStudyMatchingStatus(request);
 	}
 
 	@Operation(summary = "스터디 조기마감", description = "스터디 신청을 조기마감 시킵니다.")

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/dto/request/StudyMatchingRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/dto/request/StudyMatchingRequest.java
@@ -1,4 +1,4 @@
-package com.sejong.sejongpeer.domain.study.dto.request;
+package com.sejong.sejongpeer.domain.studyrelation.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/repository/StudyRelationRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/repository/StudyRelationRepository.java
@@ -4,6 +4,7 @@ import com.sejong.sejongpeer.domain.member.entity.Member;
 import com.sejong.sejongpeer.domain.study.entity.Study;
 import com.sejong.sejongpeer.domain.studyrelation.entity.type.StudyMatchingStatus;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -16,4 +17,6 @@ public interface StudyRelationRepository
 
 	Long countByStudyAndStatus(Study study, StudyMatchingStatus status);
 	List<StudyRelation> findByStudyId(Long studyId);
+
+	Optional<StudyRelation> findByMemberIdAndStudyId(String memberId, Long studyId);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/service/StudyRelationService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/service/StudyRelationService.java
@@ -61,6 +61,9 @@ public class StudyRelationService {
 
 		if (request.isAccept()) {
 			studyResume.changeStudyMatchingStatus(StudyMatchingStatus.ACCEPT);
+			Study appliedStudy = studyResume.getStudy();
+			appliedStudy.addParticipantsCount();
+			studyRepository.save(appliedStudy);
 		} else {
 			studyResume.changeStudyMatchingStatus(StudyMatchingStatus.REJECT);
 		}

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/service/StudyRelationService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/service/StudyRelationService.java
@@ -2,6 +2,8 @@ package com.sejong.sejongpeer.domain.studyrelation.service;
 
 import java.util.List;
 
+import com.sejong.sejongpeer.domain.member.repository.MemberRepository;
+import com.sejong.sejongpeer.domain.studyrelation.dto.request.StudyMatchingRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +31,7 @@ public class StudyRelationService {
 	private final StudyRepository studyRepository;
 	private final SmsService smsService;
 	private final StudyRelationRepository studyRelationRepository;
+	private final MemberRepository memberRepository;
 	private final MemberUtil memberUtil;
 
 	public StudyRelationCreateResponse applyStudy(StudyApplyRequest studyApplyRequest) {
@@ -47,6 +50,22 @@ public class StudyRelationService {
 		studyRelationRepository.save(newStudyapplication);
 
 		return StudyRelationCreateResponse.from(newStudyapplication);
+	}
+
+	public void updateStudyMatchingStatus(StudyMatchingRequest request) {
+		Member studyApplicant = memberRepository.findByNickname(request.applicantNickname())
+			.orElseThrow(() -> new CustomException(ErrorCode.NICKNAME_IS_NULL));
+
+		StudyRelation studyResume = studyRelationRepository.findByMemberIdAndStudyId(studyApplicant.getId(), request.studyId())
+			.orElseThrow(() -> new CustomException(ErrorCode.STUDY_APPLY_HISTORY_NOT_FOUND));
+
+		if (request.isAccept()) {
+			studyResume.changeStudyMatchingStatus(StudyMatchingStatus.ACCEPT);
+		} else {
+			studyResume.changeStudyMatchingStatus(StudyMatchingStatus.REJECT);
+		}
+
+		studyRelationRepository.save(studyResume);
 	}
 
 	public void earlyCloseRegistration(final Long studyId) {

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
 
 	// 조회 에러
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
-	NICKNAME_IS_NULL(HttpStatus.BAD_REQUEST, "닉네임이 존재하지 않습니다."),
+	NICKNAME_IS_NULL(HttpStatus.NOT_FOUND, "닉네임이 존재하지 않습니다."),
 	PHONE_NUMBER_IS_NULL(HttpStatus.BAD_REQUEST, "전화번호가 존재하지 않습니다."),
 	KAKAO_ACCOUNT_IS_NULL(HttpStatus.BAD_REQUEST, "카카오 ID가 존재하지 않습니다."),
 
@@ -55,6 +55,7 @@ public enum ErrorCode {
 	STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "스터디를 찾을 수 없습니다."),
 	STUDY_RELATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스터디의 신청내역을 찾을 수 없습니다."),
 	STUDY_NOT_OWNER(HttpStatus.FORBIDDEN, "스터디의 소유자가 아닙니다."),
+	STUDY_APPLY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저는 이 스터디 게시글에 대한 지원 이력이 없습니다."),
 
 	// Lecture
 	LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강의를 찾을 수 없습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #231 

## 📌 작업 내용 및 특이사항
- studyRelation 엔티티의 status 변경 
- 지원자의 닉네임에 대한 예외 처리 완료
- 스터디 게시글과 지원자의 지원 이력에 대한 예외 처리 완료 
- 수락 시 현재 스터디 참여 인원++ 처리 완료

## 📝 참고사항
- 

## 📚 기타
- postman 200 ok 및 DB status 변경 내역 확인 완료
- 수락 처리된 스터디 게시글 participants_count++ 확인 완료
