### PR TITLE
✨ 게시글 상세 조회 스터디 모집 인원 및 가입된 인원 수 

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
@@ -14,11 +14,11 @@ public record StudyPostInfoResponse(
 	String recruitmentEnd,
 	String content,
 	String categoryName,
-	Long numberOfAcceptedApplicants,
+	Integer participantCount,
 	Integer totalRecruitmentCount,
 	List<StudyImageUrlResponse> imgUrlList
 ) {
-	public static StudyPostInfoResponse fromStudy(Study study, String categoryName, Long numberOfApplicants) {
+	public static StudyPostInfoResponse fromStudy(Study study, String categoryName) {
 		return new StudyPostInfoResponse(
 			study.getTitle(),
 			study.getMember().getCollegeMajor().getMajor(),
@@ -27,7 +27,7 @@ public record StudyPostInfoResponse(
 			study.getRecruitmentEndAt().toString().substring(0, 10),
 			study.getContent(),
 			categoryName,
-			numberOfApplicants,
+			study.getParticipantsCount(),
 			study.getRecruitmentCount(),
 			study.getImages().stream().map(StudyImageUrlResponse::fromImage).collect(Collectors.toUnmodifiableList())
 		);

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyPostInfoResponse.java
@@ -14,7 +14,8 @@ public record StudyPostInfoResponse(
 	String recruitmentEnd,
 	String content,
 	String categoryName,
-	Long numberOfApplicants,
+	Long numberOfAcceptedApplicants,
+	Integer totalRecruitmentCount,
 	List<StudyImageUrlResponse> imgUrlList
 ) {
 	public static StudyPostInfoResponse fromStudy(Study study, String categoryName, Long numberOfApplicants) {
@@ -27,6 +28,7 @@ public record StudyPostInfoResponse(
 			study.getContent(),
 			categoryName,
 			numberOfApplicants,
+			study.getRecruitmentCount(),
 			study.getImages().stream().map(StudyImageUrlResponse::fromImage).collect(Collectors.toUnmodifiableList())
 		);
 	}

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/StudyService.java
@@ -1,7 +1,6 @@
 package com.sejong.sejongpeer.domain.study.service;
 
 import com.sejong.sejongpeer.domain.member.entity.Member;
-import com.sejong.sejongpeer.domain.study.dto.request.StudyCreateRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyPostSearchRequest;
 import com.sejong.sejongpeer.domain.study.dto.request.StudyUpdateRequest;
 import com.sejong.sejongpeer.domain.study.dto.response.*;
@@ -12,7 +11,6 @@ import com.sejong.sejongpeer.domain.study.entity.type.StudyType;
 import com.sejong.sejongpeer.domain.study.repository.ExternalActivityStudyRepository;
 import com.sejong.sejongpeer.domain.study.repository.LectureStudyRepository;
 import com.sejong.sejongpeer.domain.study.repository.StudyRepository;
-import com.sejong.sejongpeer.domain.studyrelation.entity.type.StudyMatchingStatus;
 import com.sejong.sejongpeer.domain.studyrelation.repository.StudyRelationRepository;
 import com.sejong.sejongpeer.global.error.exception.CustomException;
 import com.sejong.sejongpeer.global.error.exception.ErrorCode;
@@ -133,8 +131,7 @@ public class StudyService {
 			.orElseThrow(() -> new CustomException(ErrorCode.STUDY_NOT_FOUND));
 		String categoryName = getCategoryNameByStudyType(study);
 
-		Long acceptedApplicantsCount = studyRelationRepository.countByStudyAndStatus(study, StudyMatchingStatus.ACCEPT);
-		return StudyPostInfoResponse.fromStudy(study, categoryName, acceptedApplicantsCount);
+		return StudyPostInfoResponse.fromStudy(study, categoryName);
 	}
 
 	private String getCategoryNameByStudyType(Study study) {

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/repository/StudyRelationRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/repository/StudyRelationRepository.java
@@ -15,7 +15,6 @@ public interface StudyRelationRepository
 
 	List<StudyRelation> findByMemberAndStudy(Member member, Study study);
 
-	Long countByStudyAndStatus(Study study, StudyMatchingStatus status);
 	List<StudyRelation> findByStudyId(Long studyId);
 	List<StudyRelation> findByMember(Member member);
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #246 

## 📌 작업 내용 및 특이사항
- 기존 accept된 지원자를 나타내는 변수명이 프론트 입장에서 모호한 것 같아 수정
- 참여 인원 로직 -> count 추가 쿼리 나가지 않도록 로직 수정
- 스터디 게시글 생성 시 request로 받는 모집 전체 인원을 게시글 상세 조회 response에서도 추가 반환

## 📝 참고사항
- 

## 📚 기타
- 200 ok 확인 
