### PR TITLE
✨ 스터디 지원 취소 및 패널티 부여

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/api/StudyRelationController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/api/StudyRelationController.java
@@ -40,11 +40,11 @@ public class StudyRelationController {
 			.body(response);
 	}
 
-//	@Operation(summary = "스터디 취소", description = "스터디 신청을 취소합니다.")
-//	@DeleteMapping
-//	public ResponseEntity<?> deleteStudyRelation() {
-//		return null;
-//	}
+	@Operation(summary = "스터디 지원 취소", description = "지원했던 스터디 신청을 취소합니다.")
+	@DeleteMapping("/{studyId}")
+	public void deleteStudyRelation(@PathVariable Long studyId) {
+		studyRelationService.deleteStudyApplicationHistory(studyId);
+	}
 
 	@Operation(summary = "스터디 지원자 수락/거절", description = "자신이 개설한 스터디 지원자의 스터디 신청에 대해 수락/거절을 처리합니다.")
 	@PatchMapping("/matching/status")

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/entity/StudyRelation.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/entity/StudyRelation.java
@@ -13,6 +13,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,6 +24,8 @@ public class StudyRelation extends BaseAuditEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id")
 	private Long id;
+
+	private LocalDateTime canceledAt;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
@@ -52,5 +56,9 @@ public class StudyRelation extends BaseAuditEntity {
 
 	public void changeStudyMatchingStatus(StudyMatchingStatus status) {
 		this.status = status;
+	}
+
+	public void registerCanceledAt(LocalDateTime localDateTime) {
+		this.canceledAt = localDateTime;
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/entity/type/StudyMatchingStatus.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/entity/type/StudyMatchingStatus.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum StudyMatchingStatus {
 	PENDING("대기"),
 	ACCEPT("수락"),
-	REJECT("거부");
+	REJECT("거부"),
+	CANCEL("취소");
 
 	private final String value;
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/service/StudyRelationService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/service/StudyRelationService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.sejong.sejongpeer.domain.member.repository.MemberRepository;
 import com.sejong.sejongpeer.domain.studyrelation.dto.request.StudyMatchingRequest;
+import com.sejong.sejongpeer.global.util.SecurityUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +37,7 @@ public class StudyRelationService {
 	private final StudyRelationRepository studyRelationRepository;
 	private final MemberRepository memberRepository;
 	private final MemberUtil memberUtil;
+	private final SecurityUtil securityUtil;
 	private final TagService tagService;
 
 	public StudyRelationCreateResponse applyStudy(StudyApplyRequest studyApplyRequest) {
@@ -54,6 +56,16 @@ public class StudyRelationService {
 		studyRelationRepository.save(newStudyapplication);
 
 		return StudyRelationCreateResponse.from(newStudyapplication);
+	}
+
+	public void deleteStudyApplicationHistory(final Long studyId) {
+		String loginMemberId = securityUtil.getCurrentMemberId();
+
+		StudyRelation studyApplicationHistory = studyRelationRepository.findByMemberIdAndStudyId(loginMemberId, studyId)
+			.orElseThrow(() -> new CustomException(ErrorCode.STUDY_RELATION_NOT_FOUND));
+
+		studyRelationRepository.delete(studyApplicationHistory);
+
 	}
 
 	public void updateStudyMatchingStatus(StudyMatchingRequest request) {

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
 	STUDY_RELATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스터디의 신청내역을 찾을 수 없습니다."),
 	STUDY_NOT_OWNER(HttpStatus.FORBIDDEN, "스터디의 소유자가 아닙니다."),
 	STUDY_APPLY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저는 이 스터디 게시글에 대한 지원 이력이 없습니다."),
+	CANNOT_REAPPLY_WITHIN_AN_HOUR(HttpStatus.FORBIDDEN, "스터디 게시글을 지원했다가 취소한 유저는 1시간 동안 같은 스터디를 지원할 수 없습니다."),
 
 	// Lecture
 	LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강의를 찾을 수 없습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #251 

## 📌 작업 내용 및 특이사항
- 스터디 지원 취소
- 지원 취소 시, 같은 스터디 지원 1시간 제한 패널티 부여
- 마이페이지 내가 지원한 스터디 API 로직에서 스터디 지원을 취소하지 않은 게시글만 반환하도록 로직 수정

## 📝 참고사항
- 

## 📚 기타
- 스터디 지원 관련 예외 처리까지 모두 확인 : 중복 지원 409, 스터디 취소 후 재지원 패널티 403 
