### PR TITLE
🐛 스터디 지원 취소 및 재지원 로직 수정

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/repository/StudyRelationRepository.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/repository/StudyRelationRepository.java
@@ -13,10 +13,10 @@ import com.sejong.sejongpeer.domain.studyrelation.entity.StudyRelation;
 public interface StudyRelationRepository
 	extends JpaRepository<StudyRelation, String>, StudyRelationRepositoryCustom {
 
-	List<StudyRelation> findByMemberAndStudy(Member member, Study study);
+	Optional<StudyRelation> findTopByMemberAndStudyOrderByIdDesc(Member member, Study study);
 
 	List<StudyRelation> findByStudyId(Long studyId);
 	List<StudyRelation> findByMember(Member member);
 
-	Optional<StudyRelation> findByMemberIdAndStudyId(String memberId, Long studyId);
+	Optional<StudyRelation> findTopByMemberIdAndStudyIdOrderByIdDesc(String memberId, Long studyId);
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/service/StudyRelationService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/service/StudyRelationService.java
@@ -88,6 +88,10 @@ public class StudyRelationService {
 		StudyRelation studyResume = studyRelationRepository.findTopByMemberIdAndStudyIdOrderByIdDesc(studyApplicant.getId(), request.studyId())
 			.orElseThrow(() -> new CustomException(ErrorCode.STUDY_APPLY_HISTORY_NOT_FOUND));
 
+		if (studyResume.getStatus().equals(StudyMatchingStatus.CANCEL)) {
+			throw new CustomException(ErrorCode.INVALID_STUDY_MATHCING_STATUS_UPDATE_CONDITION);
+		}
+
 		if (request.isAccept()) {
 			studyResume.changeStudyMatchingStatus(StudyMatchingStatus.ACCEPT);
 			Study appliedStudy = studyResume.getStudy();

--- a/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/sejong/sejongpeer/global/error/exception/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
 	STUDY_NOT_OWNER(HttpStatus.FORBIDDEN, "스터디의 소유자가 아닙니다."),
 	STUDY_APPLY_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저는 이 스터디 게시글에 대한 지원 이력이 없습니다."),
 	CANNOT_REAPPLY_WITHIN_AN_HOUR(HttpStatus.FORBIDDEN, "스터디 게시글을 지원했다가 취소한 유저는 1시간 동안 같은 스터디를 지원할 수 없습니다."),
+	INVALID_STUDY_MATHCING_STATUS_UPDATE_CONDITION(HttpStatus.BAD_REQUEST, "지원을 취소한 경우 수락/거절 처리를 할 수 없습니다."),
 
 	// Lecture
 	LECTURE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 강의를 찾을 수 없습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #257 

## 📌 작업 내용 및 특이사항
- 500 error 해결

## 📝 참고사항
- 

## 📚 기타
- 스터디 첫 지원 -> 지원 취소 -> 재지원 시 패널티 로직 200 ok 확인
- 스터디 첫 지원 -> 재지원 -> 중복 지원 예외 처리 확인
- 스터디 지원 -> 취소 시 발생하는 500 에러 해결 수 200 ok 확인
