### PR TITLE
🐛 StudyTatalPostResopnse hasImage 게시글 이미지 포함 여부 로직 수정

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyTotalPostResponse.java
@@ -17,7 +17,7 @@ public record StudyTotalPostResponse(
 	List<String> tags
 ) {
 	public static StudyTotalPostResponse fromLectureStudy(Study study, String lectureName, int scrapCount) {
-		boolean hasImage = study.getImageUrl() != null;
+		boolean hasImage = !study.getImages().isEmpty();
 		return new StudyTotalPostResponse(
 			study.getId(),
 			study.getTitle(),
@@ -30,7 +30,7 @@ public record StudyTotalPostResponse(
 	}
 
 	public static StudyTotalPostResponse fromExternalActivityStudy(Study study, String activityCategoryName, int scrapCount) {
-		boolean hasImage = study.getImageUrl() != null;
+		boolean hasImage = !study.getImages().isEmpty();
 		return new StudyTotalPostResponse(
 			study.getId(),
 			study.getTitle(),


### PR DESCRIPTION
## 🌱 관련 이슈
- close #271 

## 📌 작업 내용 및 특이사항
- 게시글에 이미지가 있다면 hasImage가 true
- 피그마 게시글 목록 무한스크롤 조회 시 제목 옆 이미지 포함 여부에 따른 그림 아이콘 여부에 해당하는 data

## 📝 참고사항
- 

## 📚 기타
- 백엔드는 세종스터디 전체 기능 구현 완료
