### PR TITLE
✨ 스터디 게시글 별 모집 상태 및 지원자 매칭 상태 반환 추가

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyApplicantsListRespone.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyApplicantsListRespone.java
@@ -2,13 +2,14 @@ package com.sejong.sejongpeer.domain.study.dto.response;
 
 import java.util.List;
 
-import com.sejong.sejongpeer.domain.member.entity.Member;
 import com.sejong.sejongpeer.domain.study.entity.Study;
+import com.sejong.sejongpeer.domain.studyrelation.entity.StudyRelation;
 
 public record StudyApplicantsListRespone(
 	Long studyId,
 
 	String studyTitle,
+	String recruitmentStatus,
 	List<Applicant> applicants
 
 ) {
@@ -16,23 +17,26 @@ public record StudyApplicantsListRespone(
 		String nickname,
 		String studentId,
 		Integer grade,
-		String major
+		String major,
+		String studyMatchingStatus
 	) {
 
 	}
-	public static StudyApplicantsListRespone of (Study study, List<Member> members) {
-		List<Applicant> applicantss = members.stream()
-			.map(member -> new Applicant(
-				member.getNickname(),
-				member.getStudentId(),
-				member.getGrade(),
-				member.getCollegeMajor().getMajor()
+	public static StudyApplicantsListRespone of (Study study, List<StudyRelation> studyRelations) {
+		List<Applicant> applicantss = studyRelations.stream()
+			.map(studyRelation -> new Applicant(
+				studyRelation.getMember().getNickname(),
+				studyRelation.getMember().getStudentId(),
+				studyRelation.getMember().getGrade(),
+				studyRelation.getMember().getCollegeMajor().getMajor(),
+				studyRelation.getStatus().getValue()
 			))
 			.toList();
 
 		return new StudyApplicantsListRespone(
 			study.getId(),
 			study.getTitle(),
+			study.getRecruitmentStatus().getValue(),
 			applicantss
 		);
 	}

--- a/src/main/java/com/sejong/sejongpeer/domain/studyrelation/service/StudyRelationService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/studyrelation/service/StudyRelationService.java
@@ -171,10 +171,7 @@ public class StudyRelationService {
 		studyList.stream()
 			.forEach(study -> {
 				List<StudyRelation> relations = study.getStudyRelations();
-				List<Member> memberList = relations.stream()
-					.map(StudyRelation::getMember)
-					.toList();
-				respones.add(StudyApplicantsListRespone.of(study, memberList));
+				respones.add(StudyApplicantsListRespone.of(study, relations));
 			});
 
 		return respones;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #287 

## 📌 작업 내용 및 특이사항
- 마이페이지 자신이 작성한 스터디 게시글 지원자 목록 조회에서 게시글 모집 상태와 지원자 매칭 상태 data 추가 및 이를 위한 로직 변경 

## 📝 참고사항
- 

## 📚 기타
- 
