### PR TITLE
♻️ 교내 및 교외 스터디 게시글 작성 API를 각각 게시글 이미지 업로드 API와 통합

### DIFF
--- a/src/main/java/com/sejong/sejongpeer/domain/image/service/ImageService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/image/service/ImageService.java
@@ -205,7 +205,7 @@ public class ImageService {
 			.collect(Collectors.toUnmodifiableList());
 	}
 
-	private StudyImageUrlResponse uploadFile(Long studyId, String base64Image) throws IOException {
+	public StudyImageUrlResponse uploadFile(Long studyId, String base64Image) throws IOException {
 		String extension = "";
 		Pattern pattern = Pattern.compile("^data:image/([a-zA-Z]+);base64,");
 		Matcher matcher = pattern.matcher(base64Image);

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/ExternalActivityStudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/ExternalActivityStudyController.java
@@ -16,6 +16,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import java.io.IOException;
+
 @Tag(name = "5-2. [대외활동 스터디 생성]", description = "대외활동 스터디 게시글 작성 API입니다.")
 @RestController
 @RequiredArgsConstructor
@@ -26,7 +28,7 @@ public class ExternalActivityStudyController {
 	@Operation(summary = "외부 활동 스터디 생성", description = "외부 활동 스터디를 생성합니다.")
 	@PostMapping
 	public ResponseEntity<StudyCreateResponse> createStudy(
-		@Valid @RequestBody ExternalActivityStudyCreateRequest request) {
+		@Valid @RequestBody ExternalActivityStudyCreateRequest request) throws IOException {
 		StudyCreateResponse response = externalActivityStudyService.createStudy(request);
 
 		return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/com/sejong/sejongpeer/domain/study/api/LectureStudyController.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/api/LectureStudyController.java
@@ -16,6 +16,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import java.io.IOException;
+
 @Tag(name = "5-2. [학교수업 스터디 생성]", description = "학교수업 스터디 게시글 작성 관련 API입니다.")
 @RestController
 @RequestMapping("/api/v1/study/lecture")
@@ -27,7 +29,7 @@ public class LectureStudyController {
 	@Operation(summary = "학교수업 스터디 생성", description = "학교수업 스터디를 생성합니다.")
 	@PostMapping
 	public ResponseEntity<StudyCreateResponse> createStudy(
-		@Valid @RequestBody LectureStudyCreateRequest request) {
+		@Valid @RequestBody LectureStudyCreateRequest request) throws IOException {
 		StudyCreateResponse response = lectureStudyService.createStudy(request);
 
 		return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/ExternalActivityStudyCreateRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/ExternalActivityStudyCreateRequest.java
@@ -55,7 +55,10 @@ public record ExternalActivityStudyCreateRequest(
 	@Schema(
 		description = "모집 마감 시간",
 		defaultValue = "2023-01-03 00:00:00",
-		type = "string") LocalDateTime recruitmentEndAt
+		type = "string") LocalDateTime recruitmentEndAt,
+
+	@Schema(description = "이미지파일을 base64 인코딩한 문자열 리스트")
+	List<String> base64ImagesList
 
 ) {
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/LectureStudyCreateRequest.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/request/LectureStudyCreateRequest.java
@@ -54,7 +54,10 @@ public record LectureStudyCreateRequest(
 	@Schema(
 		description = "모집 마감 시간",
 		defaultValue = "2023-01-03 00:00:00",
-		type = "string") LocalDateTime recruitmentEndAt
+		type = "string") LocalDateTime recruitmentEndAt,
+
+	@Schema(description = "이미지파일을 base64 인코딩한 문자열 리스트")
+	List<String> base64ImagesList
 
 ) {
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyCreateResponse.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/dto/response/StudyCreateResponse.java
@@ -1,11 +1,20 @@
 package com.sejong.sejongpeer.domain.study.dto.response;
 
+import com.sejong.sejongpeer.domain.image.dto.response.StudyImageUrlResponse;
+import com.sejong.sejongpeer.domain.image.entity.Image;
 import com.sejong.sejongpeer.domain.study.entity.Study;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public record StudyCreateResponse(
-	Long id
+	Long id,
+	List<StudyImageUrlResponse> imgUrlsList
 ) {
-	public static StudyCreateResponse from(Study study) {
-		return new StudyCreateResponse(study.getId());
+	public static StudyCreateResponse from(Study study, List<StudyImageUrlResponse> imgUrlsList) {
+		return new StudyCreateResponse(
+			study.getId(),
+			imgUrlsList
+		);
 	}
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/ExternalActivityStudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/ExternalActivityStudyService.java
@@ -1,5 +1,6 @@
 package com.sejong.sejongpeer.domain.study.service;
 
+import com.sejong.sejongpeer.domain.image.dto.response.StudyImageUrlResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,9 @@ import com.sejong.sejongpeer.global.util.SecurityUtil;
 
 import lombok.RequiredArgsConstructor;
 
+import java.io.IOException;
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -30,8 +34,9 @@ public class ExternalActivityStudyService {
 	private final MemberRepository memberRepository;
 	private final SecurityUtil securityUtil;
 	private final TagService tagService;
+	private final StudyService studyService;
 
-	public StudyCreateResponse createStudy(ExternalActivityStudyCreateRequest request) {
+	public StudyCreateResponse createStudy(ExternalActivityStudyCreateRequest request) throws IOException {
 		final String memberId = securityUtil.getCurrentMemberId();
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -46,9 +51,11 @@ public class ExternalActivityStudyService {
 		tagService.setTagAndStudyTagMap(vo.tags(), savedStudy);
 
 		ExternalActivityStudy externalActivityStudy = ExternalActivityStudy.create(externalActivity, savedStudy);
+
+		List<StudyImageUrlResponse> externalActivityStudyImageUrlResponse = studyService.uploadFiles(savedStudy.getId(), request.base64ImagesList());
 		externalActivityStudyRepository.save(externalActivityStudy);
 
-		return StudyCreateResponse.from(savedStudy);
+		return StudyCreateResponse.from(savedStudy, externalActivityStudyImageUrlResponse);
 	}
 
 }

--- a/src/main/java/com/sejong/sejongpeer/domain/study/service/LectureStudyService.java
+++ b/src/main/java/com/sejong/sejongpeer/domain/study/service/LectureStudyService.java
@@ -1,5 +1,10 @@
 package com.sejong.sejongpeer.domain.study.service;
 
+import com.sejong.sejongpeer.domain.image.dto.request.StudyImageUploadRequest;
+import com.sejong.sejongpeer.domain.image.dto.response.StudyImageUrlResponse;
+import com.sejong.sejongpeer.domain.image.entity.Image;
+import com.sejong.sejongpeer.domain.image.repository.ImageRepository;
+import com.sejong.sejongpeer.domain.image.service.ImageService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +25,10 @@ import com.sejong.sejongpeer.global.util.SecurityUtil;
 
 import lombok.RequiredArgsConstructor;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -33,8 +42,9 @@ public class LectureStudyService {
 	private final MemberRepository memberRepository;
 
 	private final TagService tagService;
+	private final StudyService studyService;
 
-	public StudyCreateResponse createStudy(LectureStudyCreateRequest request) {
+	public StudyCreateResponse createStudy(LectureStudyCreateRequest request) throws IOException {
 		final String memberId = securityUtil.getCurrentMemberId();
 
 		Member member =
@@ -52,8 +62,10 @@ public class LectureStudyService {
 		tagService.setTagAndStudyTagMap(vo.tags(), saveStudy);
 
 		LectureStudy lectureStudy = LectureStudy.create(lecture, saveStudy);
+
+		List<StudyImageUrlResponse> lectureStudyImageUrlResponse = studyService.uploadFiles(saveStudy.getId(), request.base64ImagesList());
 		lectureStudyRepository.save(lectureStudy);
 
-		return StudyCreateResponse.from(saveStudy);
+		return StudyCreateResponse.from(saveStudy, lectureStudyImageUrlResponse);
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #360 

## 📌 작업 내용 및 특이사항
- 교내 수업 스터디 생성 + 해당 게시글 이미지 업로드 통합
- 교외 수업 스터디 생성 + 해당 게시글 이미지 업로드 통합
- 이미지 용량 문제로 413 상태코드 뜰 경우 게시글 정보를 DB에 저장하지 않음

## 📝 참고사항
- 

## 📚 기타
- 
